### PR TITLE
Fix `takeEvery` in `cluster` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ appendonly.aof
 Main.hs
 .stack-work
 TAGS
-stack.yaml.lock
-.nvimrc
+stack*.yaml.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
 # sudo: false
-dist: xenial
+dist: bionic
 
 cache:
   directories:
@@ -12,20 +12,24 @@ before_install:
   - mkdir -p ~/.local/bin
   - mkdir -p ~/tmp
   - export PATH=~/.local/bin:$PATH
-  - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz -C ~/tmp
-  - mv ~/tmp/stack-1.9.3-linux-x86_64/stack ~/.local/bin/
-  - curl -L https://github.com/antirez/redis/archive/5.0.2.tar.gz | tar xz -C ~/tmp
-  - cd ~/tmp/redis-5.0.2 && make
-  - ~/tmp/redis-5.0.2/src/redis-server &
+  - curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar xz -C ~/tmp
+  - mv ~/tmp/stack-2.1.3-linux-x86_64/stack ~/.local/bin/
+  # - curl -L https://github.com/antirez/redis/archive/5.0.2.tar.gz | tar xz -C ~/tmp
+  # - cd ~/tmp/redis-5.0.2 && make
+  # - ~/tmp/redis-5.0.2/src/redis-server &
+  - sudo add-apt-repository -y ppa:chris-lea/redis-server
+  - sudo apt-get update
+  - sudo apt-get -y install redis-server
   - cd ${TRAVIS_BUILD_DIR}
 
 matrix:
   include:
-    - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
+    # - env: GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
     - env: GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
     - env: GHCVER=8.2.2 STACK_YAML=stack-8.2.yaml
     - env: GHCVER=8.4.1 STACK_YAML=stack-8.4.yaml
-    - env: GHCVER=8.6.3 STACK_YAML=stack-8.6.yaml
+    - env: GHCVER=8.6.5 STACK_YAML=stack-8.6.yaml
+    - env: GHCVER=8.8.1 STACK_YAML=stack-8.8.yaml
 
   allow_failures:
    - env: GHCVER=head STACK_YAML=stack-head.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   - $HOME/.cabal
   - $HOME/.stack
 
+services:
+  - docker
+
 before_install:
   - mkdir -p ~/.local/bin
   - mkdir -p ~/tmp
@@ -21,6 +24,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y install redis-server
   - cd ${TRAVIS_BUILD_DIR}
+  - docker run -d -p 7000-7010:7000-7010 grokzen/redis-cluster:5.0.6
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: c
 # sudo: false
 dist: bionic
 
+addons:
+  apt:
+    sources:
+      - sourceline: ppa:redislabs/redis
+    packages:
+      - redis
+
 cache:
   directories:
   - $HOME/.ghc
@@ -17,12 +24,6 @@ before_install:
   - export PATH=~/.local/bin:$PATH
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz | tar xz -C ~/tmp
   - mv ~/tmp/stack-2.1.3-linux-x86_64/stack ~/.local/bin/
-  # - curl -L https://github.com/antirez/redis/archive/5.0.2.tar.gz | tar xz -C ~/tmp
-  # - cd ~/tmp/redis-5.0.2 && make
-  # - ~/tmp/redis-5.0.2/src/redis-server &
-  - sudo add-apt-repository -y ppa:chris-lea/redis-server
-  - sudo apt-get update
-  - sudo apt-get -y install redis-server
   - cd ${TRAVIS_BUILD_DIR}
   - docker run -d -p 7000-7010:7000-7010 grokzen/redis-cluster:5.0.6
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,14 @@
 # Changelog for Hedis
 
+## 0.13.1
+
+* PR #158. Upgrade to Redis 6.0.9 & Fix auth test
+* PR #160. Fix GHC 8.0.1 compat
+
+## 0.13.0
+
+* PR #159. Issue #152. Make HSET return integer instead of bool
+
 ## 0.12.15
 
 * PR #154. Implement Redis Sentinel support

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,29 @@
 # Changelog for Hedis
 
+## 0.12.15
+
+* PR #154. Implement Redis Sentinel support
+
+## 0.12.14
+
+* PR #153. Publicly expose ConnectTimeout exception
+
+## 0.12.13
+
+* PR #150, Issue #143. Leaking sockets when connection fails
+
+## 0.12.12
+
+* PR #149. Make withConnect friendly to transformer stack
+
+## 0.12.11
+
+* Expose `withCheckedConnect`, `withConnect`
+
+## 0.12.9
+
+* Expose the `Database.Redis.Core.Internal` module (see https://github.com/informatikr/hedis/issues/144 )
+
 ## 0.12.8
 
 * PR #140. Added support of +/- inf redis argument

--- a/codegen/commands.json
+++ b/codegen/commands.json
@@ -1203,7 +1203,7 @@
     ],
     "since": "2.0.0",
     "group": "hash",
-    "returns": "bool"
+    "returns": "integer"
   },
   "HSETNX": {
     "summary": "Set the value of a hash field, only if the field does not exist",

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -130,8 +130,35 @@ test-suite hedis-test
     default-language: Haskell2010
     type: exitcode-stdio-1.0
     hs-source-dirs: test
-    main-is: Test.hs
+    main-is: Main.hs
     other-modules: PubSubTest
+                   Tests
+    build-depends:
+        base == 4.*,
+        bytestring >= 0.10,
+        hedis,
+        HUnit,
+        async,
+        stm,
+        text,
+        mtl == 2.*,
+        test-framework,
+        test-framework-hunit,
+        time
+    -- We use -O0 here, since GHC takes *very* long to compile so many constants
+    ghc-options: -O0 -Wall -rtsopts -fno-warn-unused-do-bind
+    if flag(dev)
+      ghc-options: -Werror
+    if flag(dev)
+      ghc-prof-options: -auto-all
+
+test-suite hedis-test-cluster
+    default-language: Haskell2010
+    type: exitcode-stdio-1.0
+    hs-source-dirs: test
+    main-is: ClusterMain.hs
+    other-modules: PubSubTest
+                   Tests
     build-depends:
         base == 4.*,
         bytestring >= 0.10,

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -1,5 +1,5 @@
 name:               hedis
-version:            0.12.8.1
+version:            0.12.15
 synopsis:
     Client library for the Redis datastore: supports full command set,
     pipelining.
@@ -43,7 +43,7 @@ maintainer:         Kostiantyn Rybnikov <k-bx@k-bx.com>
 copyright:          Copyright (c) 2011 Falko Peters
 category:           Database
 build-type:         Simple
-cabal-version:      >=1.8
+cabal-version:      >=1.10
 homepage:           https://github.com/informatikr/hedis
 bug-reports:        https://github.com/informatikr/hedis/issues
 extra-source-files: CHANGELOG
@@ -58,6 +58,7 @@ flag dev
   manual: True
 
 library
+  default-language: Haskell2010
   hs-source-dirs:   src
   ghc-options:      -Wall -fwarn-tabs
   if impl(ghc >= 8.6.0)
@@ -67,12 +68,15 @@ library
   if flag(dev)
     ghc-prof-options: -auto-all
   exposed-modules:  Database.Redis
+                  , Database.Redis.Sentinel
+                  , Database.Redis.Core.Internal
   build-depends:    scanner >= 0.2,
                     async >= 2.1,
                     array >= 0.5.3,
                     base >= 4.8 && < 5,
                     bytestring >= 0.9,
                     bytestring-lexing >= 0.5,
+                    exceptions,
                     unordered-containers,
                     containers,
                     text,
@@ -87,7 +91,7 @@ library
                     HTTP,
                     errors,
                     network-uri,
-                    say 
+                    say
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19
@@ -108,6 +112,7 @@ library
                     Database.Redis.ConnectionContext
 
 benchmark hedis-benchmark
+    default-language: Haskell2010
     type: exitcode-stdio-1.0
     main-is: benchmark/Benchmark.hs
     build-depends:
@@ -122,6 +127,7 @@ benchmark hedis-benchmark
       ghc-prof-options: -auto-all
 
 test-suite hedis-test
+    default-language: Haskell2010
     type: exitcode-stdio-1.0
     hs-source-dirs: test
     main-is: Test.hs
@@ -146,8 +152,10 @@ test-suite hedis-test
       ghc-prof-options: -auto-all
 
 test-suite doctest
+    default-language: Haskell2010
     type: exitcode-stdio-1.0
     main-is: DocTest.hs
+    ghc-options: -O0 -rtsopts
     build-depends:
         base == 4.*,
         doctest

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -72,7 +72,6 @@ library
                   , Database.Redis.Core.Internal
   build-depends:    scanner >= 0.2,
                     async >= 2.1,
-                    array >= 0.5.3,
                     base >= 4.8 && < 5,
                     bytestring >= 0.9,
                     bytestring-lexing >= 0.5,
@@ -90,8 +89,7 @@ library
                     vector >= 0.9,
                     HTTP,
                     errors,
-                    network-uri,
-                    say
+                    network-uri
   if !impl(ghc >= 8.0)
     build-depends:
       semigroups >= 0.11 && < 0.19

--- a/hedis.cabal
+++ b/hedis.cabal
@@ -1,5 +1,5 @@
 name:               hedis
-version:            0.12.15
+version:            0.13.1
 synopsis:
     Client library for the Redis datastore: supports full command set,
     pipelining.

--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -23,7 +23,7 @@ module Database.Redis (
     -- @
     --
     -- Send commands to the server:
-    -- 
+    --
     -- @
     -- {-\# LANGUAGE OverloadedStrings \#-}
     -- ...
@@ -114,7 +114,7 @@ module Database.Redis (
     --  The Redis Scripting website (<http://redis.io/commands/eval>)
     --  documents the exact semantics of the scripting commands and value
     --  conversion.
-    
+
     -- ** Automatic Pipelining
     -- |Commands are automatically pipelined as much as possible. For example,
     --  in the above \"hello world\" example, all four commands are pipelined.
@@ -130,7 +130,7 @@ module Database.Redis (
     --  sent only when at least one reply has been received. That means, command
     --  functions may block until there are less than 1000 outstanding replies.
     --
-    
+
     -- ** Error Behavior
     -- |
     --  [Operations against keys holding the wrong kind of value:] Outside of a
@@ -155,7 +155,7 @@ module Database.Redis (
     --    sure it is not left in an unusable state, e.g. closed or inside a
     --    transaction.
     --
-    
+
     -- * The Redis Monad
     Redis(), runRedis,
     unRedis, reRedis,
@@ -163,22 +163,24 @@ module Database.Redis (
 
     -- * Connection
     Connection, ConnectError(..), connect, checkedConnect, disconnect,
+    withConnect, withCheckedConnect,
     ConnectInfo(..), defaultConnectInfo, parseConnectInfo, connectCluster,
     PortID(..),
 
     -- * Commands
     module Database.Redis.Commands,
-    
+
     -- * Transactions
     module Database.Redis.Transactions,
-    
+
     -- * Pub\/Sub
     module Database.Redis.PubSub,
 
     -- * Low-Level Command API
     sendRequest,
-    Reply(..),Status(..),RedisResult(..),ConnectionLostException(..),
-    
+    Reply(..), Status(..), RedisResult(..), ConnectionLostException(..),
+    ConnectTimeout(..),
+
     -- |[Solution to Exercise]
     --
     --  Type of 'expire' inside a transaction:
@@ -202,8 +204,10 @@ import Database.Redis.Connection
     , checkedConnect
     , connect
     , ConnectError(..)
-    , Connection(..))
-import Database.Redis.ConnectionContext(PortID(..), ConnectionLostException(..))
+    , Connection(..)
+    , withConnect
+    , withCheckedConnect)
+import Database.Redis.ConnectionContext(PortID(..), ConnectionLostException(..), ConnectTimeout(..))
 import Database.Redis.PubSub
 import Database.Redis.Protocol
 import Database.Redis.Transactions

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -101,9 +101,6 @@ instance Exception UnsupportedClusterCommandException
 newtype CrossSlotException = CrossSlotException [B.ByteString] deriving (Show, Typeable)
 instance Exception CrossSlotException
 
-newtype MultiExecCrossSlotException = MultiExecCrossSlotException (String, [[B.ByteString]]) deriving (Show, Typeable)
-instance Exception MultiExecCrossSlotException
-
 connect :: [CMD.CommandInfo] -> MVar ShardMap -> Maybe Int -> IO Connection
 connect commandInfos shardMapVar timeoutOpt = do
         shardMap <- readMVar shardMapVar
@@ -259,7 +256,7 @@ evaluateTransactionPipeline shardMapVar refreshShardmapAction conn requests' = d
     -- moved to a different node we could end up in a situation where some of
     -- the commands in a transaction are applied and some are not. Better to
     -- fail early.
-    hashSlot <- hashSlotForKeys (MultiExecCrossSlotException (show keys, requests)) keys
+    hashSlot <- hashSlotForKeys (CrossSlotException (head requests)) keys
     nodeConn <- nodeConnForHashSlot "evaluatePipeline" shardMapVar conn (MissingNodeException (head requests)) hashSlot
     resps <- requestNode nodeConn requests
     -- It's unclear what to do if one of the commands in a transaction asks us

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 module Database.Redis.Cluster
   ( Connection(..)
@@ -19,13 +20,12 @@ module Database.Redis.Cluster
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.IORef as IOR
-import Data.Maybe(listToMaybe, mapMaybe, fromMaybe)
-import Data.List(nub, sortBy)
+import Data.List(nub, sortBy, find)
 import Data.Map(fromListWith, assocs)
 import Data.Function(on)
 import Control.Exception(Exception, throwIO, BlockedIndefinitelyOnMVar(..), catches, Handler(..))
 import Control.Concurrent.MVar(MVar, newMVar, readMVar, modifyMVar, modifyMVar_)
-import Control.Monad(zipWithM, when)
+import Control.Monad(zipWithM, when, replicateM)
 import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)
 import qualified Database.Redis.ConnectionContext as CC
 import qualified Data.HashMap.Strict as HM
@@ -60,7 +60,23 @@ instance Eq NodeConnection where
 instance Ord NodeConnection where
     compare (NodeConnection _ _ id1) (NodeConnection _ _ id2) = compare id1 id2
 
-data PipelineState = Pending [[B.ByteString]] | Executed [Reply]
+data PipelineState =
+      -- Nothing in the pipeline has been evaluated yet so nothing has been
+      -- sent
+      Pending [[B.ByteString]]
+      -- This pipeline has been executed, the replies are contained within it
+    | Executed [Reply]
+      -- We're in a MULTI-EXEC transaction. All commands in the transaction
+      -- should go to the same node, but we won't know what node that is until
+      -- we see a command with a key. We're storing these transactions and will
+      -- send them all together when we see an EXEC.
+    | TransactionPending [[B.ByteString]]
+-- A pipeline has an MVar for the current state, this state is actually always
+-- `Pending` because the first thing the implementation does when executing a
+-- pipeline is to take the current pipeline state out of the MVar and replace
+-- it with a new `Pending` state. The executed state is held on to by the
+-- replies within it.
+
 newtype Pipeline = Pipeline (MVar PipelineState)
 
 data NodeRole = Master | Slave deriving (Show, Eq, Ord)
@@ -85,6 +101,8 @@ instance Exception UnsupportedClusterCommandException
 newtype CrossSlotException = CrossSlotException [B.ByteString] deriving (Show, Typeable)
 instance Exception CrossSlotException
 
+newtype MultiExecCrossSlotException = MultiExecCrossSlotException (String, [[B.ByteString]]) deriving (Show, Typeable)
+instance Exception MultiExecCrossSlotException
 
 connect :: [CMD.CommandInfo] -> MVar ShardMap -> Maybe Int -> IO Connection
 connect commandInfos shardMapVar timeoutOpt = do
@@ -111,20 +129,48 @@ disconnect (Connection nodeConnMap _ _ _) = mapM_ disconnectNode (HM.elems nodeC
 requestPipelined :: IO ShardMap -> Connection -> [B.ByteString] -> IO Reply
 requestPipelined refreshAction conn@(Connection _ pipelineVar shardMapVar _) nextRequest = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
     (newStateVar, repliesIndex) <- hasLocked "locked adding to pipeline" $ modifyMVar stateVar $ \case
-        Pending requests -> return (Pending (nextRequest:requests), (stateVar, length requests))
+        Pending requests | isMulti nextRequest -> do
+            replies <- evaluatePipeline shardMapVar refreshAction conn requests
+            s' <- newMVar $ TransactionPending [nextRequest]
+            return (Executed replies, (s', 0))
+        Pending requests | length requests > 1000 -> do
+            replies <- evaluatePipeline shardMapVar refreshAction conn (nextRequest:requests)
+            return (Executed replies, (stateVar, length requests))
+        Pending requests ->
+            return (Pending (nextRequest:requests), (stateVar, length requests))
+        TransactionPending requests ->
+            if isExec nextRequest then do
+              replies <- evaluateTransactionPipeline shardMapVar refreshAction conn (nextRequest:requests)
+              return (Executed replies, (stateVar, length requests))
+            else
+              return (TransactionPending (nextRequest:requests), (stateVar, length requests))
         e@(Executed _) -> do
-            s' <- newMVar $ Pending [nextRequest]
+            s' <- newMVar $
+                    if isMulti nextRequest then
+                        TransactionPending [nextRequest]
+                    else
+                        Pending [nextRequest]
             return (e, (s', 0))
     evaluateAction <- unsafeInterleaveIO $ do
         replies <- hasLocked "locked evaluating replies" $ modifyMVar newStateVar $ \case
-            Executed replies -> return (Executed replies, replies)
+            Executed replies ->
+                return (Executed replies, replies)
             Pending requests-> do
                 replies <- evaluatePipeline shardMapVar refreshAction conn requests
+                return (Executed replies, replies)
+            TransactionPending requests-> do
+                replies <- evaluateTransactionPipeline shardMapVar refreshAction conn requests
                 return (Executed replies, replies)
         return $ replies !! repliesIndex
     return (Pipeline newStateVar, evaluateAction)
 
+isMulti :: [B.ByteString] -> Bool
+isMulti ("MULTI" : _) = True
+isMulti _ = False
 
+isExec :: [B.ByteString] -> Bool
+isExec ("EXEC" : _) = True
+isExec _ = False
 
 data PendingRequest = PendingRequest Int [B.ByteString]
 data CompletedRequest = CompletedRequest Int [B.ByteString] Reply
@@ -157,28 +203,28 @@ evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
         shardMap <- hasLocked "reading shardmap in evaluatePipeline" $ readMVar shardMapVar
         requestsByNode <- getRequestsByNode shardMap
         resps <- concat <$> mapM (uncurry executeRequests) requestsByNode
-        _ <- when (any (moved . rawResponse) resps) (refreshShardMapVar "locked refreshing due to moved responses")
+        when (any (moved . rawResponse) resps) (refreshShardMapVar "locked refreshing due to moved responses")
         retriedResps <- mapM (retry 0) resps
         return $ map rawResponse $ sortBy (on compare responseIndex) retriedResps
   where
     getRequestsByNode :: ShardMap -> IO [(NodeConnection, [PendingRequest])]
     getRequestsByNode shardMap = do
-        commandsWithNodes <- zipWithM (requestWithNode shardMap) (reverse [0..(length requests - 1)]) requests
-        return $ assocs $ fromListWith (++) commandsWithNodes
-    requestWithNode :: ShardMap -> Int -> [B.ByteString] -> IO (NodeConnection, [PendingRequest])
-    requestWithNode shardMap index request = do
-        nodeConn <- nodeConnectionForCommand conn shardMap request
-        return (nodeConn, [PendingRequest index request])
+        commandsWithNodes <- zipWithM (requestWithNodes shardMap) (reverse [0..(length requests - 1)]) requests
+        return $ assocs $ fromListWith (++) (mconcat commandsWithNodes)
+    requestWithNodes :: ShardMap -> Int -> [B.ByteString] -> IO [(NodeConnection, [PendingRequest])]
+    requestWithNodes shardMap index request = do
+        nodeConns <- nodeConnectionForCommand conn shardMap request
+        return $ (, [PendingRequest index request]) <$> nodeConns
     executeRequests :: NodeConnection -> [PendingRequest] -> IO [CompletedRequest]
     executeRequests nodeConn nodeRequests = do
         replies <- requestNode nodeConn $ map rawRequest nodeRequests
-        return $ map (\(PendingRequest i r, rep) -> CompletedRequest i r rep) (zip nodeRequests replies)
+        return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
     retry :: Int -> CompletedRequest -> IO CompletedRequest
     retry retryCount resp@(CompletedRequest index request thisReply) = do
         retryReply <- case thisReply of
             (Error errString) | B.isPrefixOf "MOVED" errString -> do
                 shardMap <- hasLocked "reading shard map in retry MOVED" $ readMVar shardMapVar
-                nodeConn <- nodeConnectionForCommand conn shardMap (requestForResponse resp)
+                nodeConn <- head <$> nodeConnectionForCommand conn shardMap (requestForResponse resp)
                 head <$> requestNode nodeConn [request]
             (askingRedirection -> Just (host, port)) -> do
                 shardMap <- hasLocked "reading shardmap in retry ASK" $ readMVar shardMapVar
@@ -195,6 +241,53 @@ evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
     refreshShardMapVar :: String -> IO ()
     refreshShardMapVar msg = hasLocked msg $ modifyMVar_ shardMapVar (const refreshShardmapAction)
 
+-- Like `evaluateOnPipeline`, except we expect to be able to run all commands
+-- on a single shard. Failing to meet this expectation is an error.
+evaluateTransactionPipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> IO [Reply]
+evaluateTransactionPipeline shardMapVar refreshShardmapAction conn requests' = do
+    let requests = reverse requests'
+    (ShardMap shardMap) <- hasLocked "reading shardmap in evaluatePipeline" $ readMVar shardMapVar
+    let (Connection nodeConns _ _ infoMap) = conn
+    keys <- mconcat <$> mapM (requestKeys infoMap) requests
+    -- In cluster mode Redis expects commands in transactions to all work on the
+    -- same hashslot. We find that hashslot here.
+    -- We could be more permissive and allow transactions that touch multiple
+    -- hashslots, as long as those hashslots are on the same node. This allows
+    -- a new failure case though: if some of the transactions hashslots are
+    -- moved to a different node we could end up in a situation where some of
+    -- the commands in a transaction are applied and some are not. Better to
+    -- fail early.
+    hashSlot <- hashSlotForKeys (MultiExecCrossSlotException (show keys, requests)) keys
+    node <-
+        case IntMap.lookup (fromEnum hashSlot) shardMap of
+            Nothing -> throwIO $ MissingNodeException (head requests)
+            Just (Shard master _) -> return master
+    nodeConn <-
+        case HM.lookup (nodeId node) nodeConns of
+            Nothing -> throwIO $ MissingNodeException (head requests)
+            Just nodeConn' -> return nodeConn'
+    resps <- requestNode nodeConn requests
+    -- It's unclear what to do if one of the commands in a transaction asks us
+    -- to redirect. Run only the redirected commands in another transaction?
+    -- That doesn't seem very transactional.
+    when (any moved resps)
+      (hasLocked "locked refreshing due to moved responses" $ modifyMVar_ shardMapVar (const refreshShardmapAction))
+    return resps
+
+hashSlotForKeys :: Exception e => e -> [B.ByteString] -> IO HashSlot
+hashSlotForKeys exception keys =
+    case nub (keyToSlot <$> keys) of
+        -- If none of the commands contain a key we can send them to any
+        -- node. Let's pick the first one.
+        [] -> return 0
+        [hashSlot] -> return hashSlot
+        _ -> throwIO $ exception
+
+requestKeys :: CMD.InfoMap -> [B.ByteString] -> IO [B.ByteString]
+requestKeys infoMap request =
+    case CMD.keysForRequest infoMap request of
+        Nothing -> throwIO $ UnsupportedClusterCommandException request
+        Just k -> return k
 
 askingRedirection :: Reply -> Maybe (Host, Port)
 askingRedirection (Error errString) = case Char8.words errString of
@@ -218,34 +311,37 @@ nodeConnWithHostAndPort shardMap (Connection nodeConns _ _ _) host port = do
     node <- nodeWithHostAndPort shardMap host port
     HM.lookup (nodeId node) nodeConns
 
-nodeConnectionForCommand :: Connection -> ShardMap -> [B.ByteString] -> IO NodeConnection
-nodeConnectionForCommand (Connection nodeConns _ _ infoMap) (ShardMap shardMap) request = do
-    let mek = case request of
-          ("MULTI" : key : _) -> Just [key]
-          ("EXEC" : key : _) -> Just [key]
-          _ -> Nothing
-    keys <- case CMD.keysForRequest infoMap request of
-        Nothing -> throwIO $ UnsupportedClusterCommandException request
-        Just k -> return k
-    let shards = nub $ mapMaybe ((flip IntMap.lookup shardMap) . fromEnum . keyToSlot) (fromMaybe keys mek)
-    node <- case shards of
-        [] -> throwIO $ MissingNodeException request
-        [Shard master _] -> return master
-        _ -> throwIO $ CrossSlotException request
-    maybe (throwIO $ MissingNodeException request) return (HM.lookup (nodeId node) nodeConns)
+nodeConnectionForCommand :: Connection -> ShardMap -> [B.ByteString] -> IO [NodeConnection]
+nodeConnectionForCommand conn@(Connection nodeConns _ _ infoMap) (ShardMap shardMap) request =
+    case request of
+        ("FLUSHALL" : _) -> allNodes
+        ("FLUSHDB" : _) -> allNodes
+        ("QUIT" : _) -> allNodes
+        ("UNWATCH" : _) -> allNodes
+        _ -> do
+            keys <- requestKeys infoMap request
+            hashSlot <- hashSlotForKeys (CrossSlotException request) keys
+            node <- case IntMap.lookup (fromEnum hashSlot) shardMap of
+                Nothing -> throwIO $ MissingNodeException request
+                Just (Shard master _) -> return master
+            maybe (throwIO $ MissingNodeException request) (return . return) (HM.lookup (nodeId node) nodeConns)
+    where
+        allNodes =
+            case allMasterNodes conn (ShardMap shardMap) of
+                Nothing -> throwIO $ MissingNodeException request
+                Just allNodes' -> return allNodes'
 
-cleanRequest :: [B.ByteString] -> [B.ByteString]
-cleanRequest ("MULTI" : _) = ["MULTI"]
-cleanRequest ("EXEC" : _) = ["EXEC"]
-cleanRequest req = req
-
+allMasterNodes :: Connection -> ShardMap -> Maybe [NodeConnection]
+allMasterNodes (Connection nodeConns _ _ _) (ShardMap shardMap) =
+    mapM (flip HM.lookup nodeConns . nodeId) masterNodes
+  where
+    masterNodes = (\(Shard master _) -> master) <$> nub (IntMap.elems shardMap)
 
 requestNode :: NodeConnection -> [[B.ByteString]] -> IO [Reply]
 requestNode (NodeConnection ctx lastRecvRef _) requests = do
-    let reqs = map cleanRequest requests
-    _ <- mapM_ (sendNode . renderRequest) reqs
+    mapM_ (sendNode . renderRequest) requests
     _ <- CC.flush ctx
-    sequence $ take (length requests) (repeat recvNode)
+    replicateM (length requests) recvNode
 
     where
 
@@ -272,7 +368,7 @@ nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shar
 
 
 nodeWithHostAndPort :: ShardMap -> Host -> Port -> Maybe Node
-nodeWithHostAndPort shardMap host port = listToMaybe $ filter (\(Node _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) $ nodes shardMap
+nodeWithHostAndPort shardMap host port = find (\(Node _ _ nodeHost nodePort) -> port == nodePort && host == nodeHost) (nodes shardMap)
 
 nodeId :: Node -> NodeID
 nodeId (Node theId _ _ _) = theId

--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -121,9 +121,8 @@ readNumKeys (rawNumKeys:rest) = do
 readNumKeys _ = Nothing
 
 takeEvery :: Int -> [a] -> [a]
-takeEvery n xs = case drop (n-1) xs of
-      (y:ys) -> y : takeEvery n ys
-      [] -> []
+takeEvery _ [] = []
+takeEvery n (x:xs) = x : takeEvery n (drop (n-1) xs)
 
 readMaybe :: Read a => String -> Maybe a
 readMaybe s = case reads s of

--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -128,8 +128,22 @@ parseMovable ("EVAL":_:rest) = readNumKeys rest
 parseMovable ("EVALSHA":_:rest) = readNumKeys rest
 parseMovable ("ZUNIONSTORE":_:rest) = readNumKeys rest
 parseMovable ("ZINTERSTORE":_:rest) = readNumKeys rest
+parseMovable ("XREAD":rest) = readXreadKeys rest
+parseMovable ("XREADGROUP":"GROUP":_:_:rest) = readXreadgroupKeys rest
 parseMovable _ = Nothing
 
+readXreadKeys :: [BS.ByteString] -> Maybe [BS.ByteString]
+readXreadKeys ("COUNT":_:rest) = readXreadKeys rest
+readXreadKeys ("BLOCK":_:rest) = readXreadKeys rest
+readXreadKeys ("STREAMS":rest) = Just $ take (length rest `div` 2) rest
+readXreadKeys _ = Nothing
+
+readXreadgroupKeys :: [BS.ByteString] -> Maybe [BS.ByteString]
+readXreadgroupKeys ("COUNT":_:rest) = readXreadKeys rest
+readXreadgroupKeys ("BLOCK":_:rest) = readXreadKeys rest
+readXreadgroupKeys ("NOACK":rest) = readXreadKeys rest
+readXreadgroupKeys ("STREAMS":rest) = Just $ take (length rest `div` 2) rest
+readXreadgroupKeys _ = Nothing
 
 readNumKeys :: [BS.ByteString] -> Maybe [BS.ByteString]
 readNumKeys (rawNumKeys:rest) = do

--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -119,7 +119,9 @@ readNumKeys (rawNumKeys:rest) = do
     numKeys <- readMaybe (Char8.unpack rawNumKeys)
     return $ take numKeys rest
 readNumKeys _ = Nothing
-
+-- takeEvery 1 [1,2,3,4,5] ->[1,2,3,4,5]
+-- takeEvery 2 [1,2,3,4,5] ->[1,3,5]
+-- takeEvery 3 [1,2,3,4,5] ->[1,4]
 takeEvery :: Int -> [a] -> [a]
 takeEvery _ [] = []
 takeEvery n (x:xs) = x : takeEvery n (drop (n-1) xs)

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -843,7 +843,7 @@ hset
     => ByteString -- ^ key
     -> ByteString -- ^ field
     -> ByteString -- ^ value
-    -> m (f Bool)
+    -> m (f Integer)
 hset key field value = sendRequest (["HSET"] ++ [encode key] ++ [encode field] ++ [encode value] )
 
 brpoplpush

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -189,6 +189,12 @@ instance Exception ClusterConnectError
 
 -- |Constructs a 'ShardMap' of connections to clustered nodes. The argument is
 -- a 'ConnectInfo' for any node in the cluster
+--
+-- Some Redis commands are currently not supported in cluster mode
+-- - CONFIG, AUTH
+-- - SCAN
+-- - MOVE, SELECT
+-- - PUBLISH, SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE, PUNSUBSCRIBE, RESET
 connectCluster :: ConnectInfo -> IO Connection
 connectCluster bootstrapConnInfo = do
     conn <- createConnection bootstrapConnInfo

--- a/src/Database/Redis/ConnectionContext.hs
+++ b/src/Database/Redis/ConnectionContext.hs
@@ -43,7 +43,7 @@ data Connection = Connection
     , lastRecvRef :: IOR.IORef (Maybe B.ByteString) }
 
 instance Show Connection where
-    show Connection{..} = "Connection{ ctx = " <> show ctx <> ", lastRecvRef = IORef}"
+    show Connection{..} = "Connection{ ctx = " ++ show ctx ++ ", lastRecvRef = IORef}"
 
 data ConnectPhase
   = PhaseUnknown

--- a/src/Database/Redis/Core.hs
+++ b/src/Database/Redis/Core.hs
@@ -15,17 +15,10 @@ import Prelude
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
 #endif
-#if __GLASGOW_HASKELL__ > 711
-#endif
 import Control.Monad.Reader
-#if MIN_VERSION_base(4,13,0)
-
-#else
-import Control.Monad.Fail(MonadFail)
-#endif
 import qualified Data.ByteString as B
 import Data.IORef
-
+import Database.Redis.Core.Internal
 import Database.Redis.Protocol
 import qualified Database.Redis.ProtocolPipelining as PP
 import Database.Redis.Types
@@ -35,25 +28,6 @@ import qualified Database.Redis.Cluster as Cluster
 --------------------------------------------------------------------------------
 -- The Redis Monad
 --
-
--- |Context for normal command execution, outside of transactions. Use
---  'runRedis' to run actions of this type.
---
---  In this context, each result is wrapped in an 'Either' to account for the
---  possibility of Redis returning an 'Error' reply.
-newtype Redis a = Redis (ReaderT RedisEnv IO a)
-    deriving (Monad, MonadIO, Functor, Applicative)
-
-#if __GLASGOW_HASKELL__ > 711
-deriving instance MonadFail Redis
-#endif
-
-data RedisEnv
-    = NonClusteredEnv { envConn :: PP.Connection, envLastReply :: IORef Reply }
-    | ClusteredEnv
-        { refreshAction :: IO ShardMap
-        , connection :: Cluster.Connection
-        }
 
 -- |This class captures the following behaviour: In a context @m@, a command
 --  will return its result wrapped in a \"container\" of type @f@.

--- a/src/Database/Redis/Core/Internal.hs
+++ b/src/Database/Redis/Core/Internal.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Database.Redis.Core.Internal where
+#if __GLASGOW_HASKELL__ > 711 && __GLASGOW_HASKELL__ < 808
+import Control.Monad.Fail (MonadFail)
+#endif
+import Control.Monad.Reader
+import Data.IORef
+import Database.Redis.Protocol
+import qualified Database.Redis.ProtocolPipelining as PP
+import qualified Database.Redis.Cluster as Cluster
+
+-- |Context for normal command execution, outside of transactions. Use
+--  'runRedis' to run actions of this type.
+--
+--  In this context, each result is wrapped in an 'Either' to account for the
+--  possibility of Redis returning an 'Error' reply.
+newtype Redis a =
+  Redis (ReaderT RedisEnv IO a)
+  deriving (Monad, MonadIO, Functor, Applicative)
+#if __GLASGOW_HASKELL__ > 711
+deriving instance MonadFail Redis
+#endif
+data RedisEnv
+    = NonClusteredEnv { envConn :: PP.Connection, envLastReply :: IORef Reply }
+    | ClusteredEnv
+        { refreshAction :: IO Cluster.ShardMap
+        , connection :: Cluster.Connection
+        }

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -47,7 +47,6 @@ data Connection = Conn
 fromCtx :: CC.ConnectionContext -> IO Connection
 fromCtx ctx = Conn ctx <$> newIORef [] <*> newIORef [] <*> newIORef 0
 
-
 connect :: NS.HostName -> CC.PortID -> Maybe Int -> IO Connection
 connect hostName portId timeoutOpt = do
     connCtx <- CC.connect hostName portId timeoutOpt

--- a/src/Database/Redis/PubSub.hs
+++ b/src/Database/Redis/PubSub.hs
@@ -33,8 +33,7 @@ import Data.ByteString.Char8 (ByteString)
 import Data.List (foldl')
 import Data.Maybe (isJust)
 import Data.Pool
-#if MIN_VERSION_base(4,13,0)
-#else
+#if __GLASGOW_HASKELL__ < 808
 import Data.Semigroup (Semigroup(..))
 #endif
 import qualified Data.HashMap.Strict as HM
@@ -92,7 +91,7 @@ instance Semigroup (Cmd Subscribe a) where
 instance Monoid (Cmd Subscribe a) where
   mempty = DoNothing
   mappend = (<>)
-    
+
 instance Semigroup (Cmd Unsubscribe a) where
   (<>) DoNothing x = x
   (<>) x DoNothing = x
@@ -183,7 +182,7 @@ unsubscribe
     -> PubSub
 unsubscribe cs = mempty{ unsubs = Cmd cs }
 
--- |Listen for messages published to channels matching the given patterns 
+-- |Listen for messages published to channels matching the given patterns
 --  (<http://redis.io/commands/psubscribe>).
 psubscribe
     :: [ByteString] -- ^ pattern
@@ -191,7 +190,7 @@ psubscribe
 psubscribe []       = mempty
 psubscribe ps = mempty{ psubs = Cmd ps }
 
--- |Stop listening for messages posted to channels matching the given patterns 
+-- |Stop listening for messages posted to channels matching the given patterns
 --  (<http://redis.io/commands/punsubscribe>).
 punsubscribe
     :: [ByteString] -- ^ pattern
@@ -201,11 +200,11 @@ punsubscribe ps = mempty{ punsubs = Cmd ps }
 -- |Listens to published messages on subscribed channels and channels matching
 --  the subscribed patterns. For documentation on the semantics of Redis
 --  Pub\/Sub see <http://redis.io/topics/pubsub>.
---  
---  The given callback function is called for each received message. 
+--
+--  The given callback function is called for each received message.
 --  Subscription changes are triggered by the returned 'PubSub'. To keep
 --  subscriptions unchanged, the callback can return 'mempty'.
---  
+--
 --  Example: Subscribe to the \"news\" channel indefinitely.
 --
 --  @

--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -1,0 +1,218 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE StrictData        #-}
+{-# LANGUAGE TypeApplications  #-}
+
+-- | "Database.Redis" like interface with connection through Redis Sentinel.
+--
+-- More details here: <https://redis.io/topics/sentinel>.
+--
+-- Example:
+--
+-- @
+-- conn <- 'connect' 'SentinelConnectionInfo' (("localhost", PortNumber 26379) :| []) "mymaster" 'defaultConnectInfo'
+--
+-- 'runRedis' conn $ do
+--   'set' "hello" "world"
+-- @
+--
+-- When connection is opened, the Sentinels will be queried to get current master. Subsequent 'runRedis'
+-- calls will talk to that master.
+--
+-- If 'runRedis' call fails, the next call will choose a new master to talk to.
+--
+-- This implementation is based on Gist by Emanuel Borsboom
+-- at <https://gist.github.com/borsboom/681d37d273d5c4168723>
+module Database.Redis.Sentinel
+  (
+    -- * Connection
+    SentinelConnectInfo(..)
+  , SentinelConnection
+  , connect
+    -- * runRedis with Sentinel support
+  , runRedis
+  , RedisSentinelException(..)
+
+    -- * Re-export Database.Redis
+  , module Database.Redis
+  ) where
+
+import           Control.Concurrent
+import           Control.Exception     (Exception, IOException, evaluate, throwIO)
+import           Control.Monad
+import           Control.Monad.Catch   (Handler (..), MonadCatch, catches, throwM)
+import           Control.Monad.Except
+import           Data.ByteString       (ByteString)
+import qualified Data.ByteString       as BS
+import qualified Data.ByteString.Char8 as BS8
+import           Data.Foldable         (toList)
+import           Data.List             (delete)
+import           Data.List.NonEmpty    (NonEmpty (..))
+import           Data.Typeable         (Typeable)
+import           Data.Unique
+import           Network.Socket        (HostName)
+
+import           Database.Redis hiding (Connection, connect, runRedis)
+import qualified Database.Redis as Redis
+
+-- | Interact with a Redis datastore.  See 'Database.Redis.runRedis' for details.
+runRedis :: SentinelConnection
+         -> Redis (Either Reply a)
+         -> IO (Either Reply a)
+runRedis (SentinelConnection connMVar) action = do
+  (baseConn, preToken) <- modifyMVar connMVar $ \oldConnection@SentinelConnection'
+          { rcCheckFailover
+          , rcToken = oldToken
+          , rcSentinelConnectInfo = oldConnectInfo
+          , rcMasterConnectInfo = oldMasterConnectInfo
+          , rcBaseConnection = oldBaseConnection } ->
+      if rcCheckFailover
+        then do
+          (newConnectInfo, newMasterConnectInfo) <- updateMaster oldConnectInfo
+          newToken <- newUnique
+          (connInfo, conn) <-
+            if sameHost newMasterConnectInfo oldMasterConnectInfo
+              then return (oldMasterConnectInfo, oldBaseConnection)
+              else do
+                newConn <- Redis.connect newMasterConnectInfo
+                return (newMasterConnectInfo, newConn)
+
+          return
+            ( SentinelConnection'
+              { rcCheckFailover = False
+              , rcToken = newToken
+              , rcSentinelConnectInfo = newConnectInfo
+              , rcMasterConnectInfo = connInfo
+              , rcBaseConnection = conn
+              }
+            , (conn, newToken)
+            )
+        else return (oldConnection, (oldBaseConnection, oldToken))
+
+  -- Use evaluate to make sure we catch exceptions from 'runRedis'.
+  reply <- (Redis.runRedis baseConn action >>= evaluate)
+    `catchRedisRethrow` (\_ -> setCheckSentinel preToken)
+  case reply of
+    Left (Error e) | "READONLY " `BS.isPrefixOf` e ->
+        -- This means our connection has turned into a slave
+        setCheckSentinel preToken
+    _ -> return ()
+  return reply
+
+  where
+    sameHost :: Redis.ConnectInfo -> Redis.ConnectInfo -> Bool
+    sameHost l r = connectHost l == connectHost r && connectPort l == connectPort r
+
+    setCheckSentinel preToken = modifyMVar_ connMVar $ \conn@SentinelConnection'{rcToken} ->
+      if preToken == rcToken
+        then do
+          newToken <- newUnique
+          return (conn{rcToken = newToken, rcCheckFailover = True})
+        else return conn
+
+
+connect :: SentinelConnectInfo -> IO SentinelConnection
+connect origConnectInfo = do
+  (connectInfo, masterConnectInfo) <- updateMaster origConnectInfo
+  conn <- Redis.connect masterConnectInfo
+  token <- newUnique
+
+  SentinelConnection <$> newMVar SentinelConnection'
+    { rcCheckFailover = False
+    , rcToken = token
+    , rcSentinelConnectInfo = connectInfo
+    , rcMasterConnectInfo = masterConnectInfo
+    , rcBaseConnection = conn
+    }
+
+updateMaster :: SentinelConnectInfo
+             -> IO (SentinelConnectInfo, Redis.ConnectInfo)
+updateMaster sci@SentinelConnectInfo{..} = do
+    -- This is using the Either monad "backwards" -- Left means stop because we've made a connection,
+    -- Right means try again.
+    resultEither <- runExceptT $ forM_ connectSentinels $ \(host, port) -> do
+      trySentinel host port `catchRedis` (\_ -> return ())
+
+
+    case resultEither of
+        Left (conn, sentinelPair) -> return
+          ( sci
+            { connectSentinels = sentinelPair :| delete sentinelPair (toList connectSentinels)
+            }
+          , conn
+          )
+        Right () -> throwIO $ NoSentinels connectSentinels
+  where
+    trySentinel :: HostName -> PortID -> ExceptT (Redis.ConnectInfo, (HostName, PortID)) IO ()
+    trySentinel sentinelHost sentinelPort = do
+      -- bang to ensure exceptions from runRedis get thrown immediately.
+      !replyE <- liftIO $ do
+        !sentinelConn <- Redis.connect $ Redis.defaultConnectInfo
+            { connectHost = sentinelHost
+            , connectPort = sentinelPort
+            , connectMaxConnections = 1
+            }
+        Redis.runRedis sentinelConn $ sendRequest
+          ["SENTINEL", "get-master-addr-by-name", connectMasterName]
+
+      case replyE of
+        Right [host, port] ->
+          throwError
+            ( connectBaseInfo
+              { connectHost = BS8.unpack host
+              , connectPort =
+                  maybe
+                    (PortNumber 26379)
+                    (PortNumber . fromIntegral . fst)
+                    $ BS8.readInt port
+              }
+            , (sentinelHost, sentinelPort)
+            )
+        _ -> return ()
+
+catchRedisRethrow :: MonadCatch m => m a -> (String -> m ()) -> m a
+catchRedisRethrow action handler =
+  action `catches`
+    [ Handler $ \ex -> handler (show @IOException ex) >> throwM ex
+    , Handler $ \ex -> handler (show @ConnectionLostException ex) >> throwM ex
+    ]
+
+catchRedis :: MonadCatch m => m a -> (String -> m a) -> m a
+catchRedis action handler =
+  action `catches`
+    [ Handler $ \ex -> handler (show @IOException ex)
+    , Handler $ \ex -> handler (show @ConnectionLostException ex)
+    ]
+
+newtype SentinelConnection = SentinelConnection (MVar SentinelConnection')
+
+data SentinelConnection'
+  = SentinelConnection'
+      { rcCheckFailover       :: Bool
+      , rcToken               :: Unique
+      , rcSentinelConnectInfo :: SentinelConnectInfo
+      , rcMasterConnectInfo   :: Redis.ConnectInfo
+      , rcBaseConnection      :: Redis.Connection
+      }
+
+-- | Configuration of Sentinel hosts.
+data SentinelConnectInfo
+  = SentinelConnectInfo
+      { connectSentinels  :: NonEmpty (HostName, PortID)
+        -- ^ List of sentinels.
+      , connectMasterName :: ByteString
+        -- ^ Name of master to connect to.
+      , connectBaseInfo   :: Redis.ConnectInfo
+        -- ^ This is used to configure auth and other parameters for Redis connection,
+        -- but 'Redis.connectHost' and 'Redis.connectPort' are ignored.
+      }
+  deriving (Show)
+
+-- | Exception thrown by "Database.Redis.Sentinel".
+data RedisSentinelException
+  = NoSentinels (NonEmpty (HostName, PortID))
+    -- ^ Thrown if no sentinel can be reached.
+  deriving (Show, Typeable, Exception)

--- a/src/Database/Redis/Sentinel.hs
+++ b/src/Database/Redis/Sentinel.hs
@@ -1,10 +1,11 @@
-{-# LANGUAGE BangPatterns      #-}
-{-# LANGUAGE DeriveAnyClass    #-}
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE StrictData        #-}
-{-# LANGUAGE TypeApplications  #-}
+{-# LANGUAGE BangPatterns       #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE RecordWildCards    #-}
+{-# LANGUAGE StrictData         #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | "Database.Redis" like interface with connection through Redis Sentinel.
 --
@@ -215,4 +216,6 @@ data SentinelConnectInfo
 data RedisSentinelException
   = NoSentinels (NonEmpty (HostName, PortID))
     -- ^ Thrown if no sentinel can be reached.
-  deriving (Show, Typeable, Exception)
+  deriving (Show, Typeable)
+
+deriving instance Exception RedisSentinelException

--- a/src/Database/Redis/URL.hs
+++ b/src/Database/Redis/URL.hs
@@ -8,8 +8,7 @@ import Control.Applicative ((<$>))
 #endif
 import Control.Error.Util (note)
 import Control.Monad (guard)
-#if MIN_VERSION_base(4,13,0)
-#else
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid ((<>))
 #endif
 import Database.Redis.Connection (ConnectInfo(..), defaultConnectInfo)

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.5
+resolver: nightly-2019-11-29
 packages:
 - '.'
 extra-deps:

--- a/stack-head.yaml
+++ b/stack-head.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.3
+resolver: nightly-2019-11-29
 packages:
 - '.'
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.15
+resolver: lts-16.18
 packages:
   - '.'
 flags:

--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -22,6 +22,7 @@ tests conn = map ($conn) $ concat
     [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
     , testsZSets, [testTransaction], [testScripting]
     , testsConnection, testsServer, [testSScan, testHScan, testZScan], [testZrangelex]
+    , [testXAddRead, testXReadGroup, testXRange, testXpending, testXClaim, testXInfo, testXDel, testXTrim]
       -- should always be run last as connection gets closed after it
     , [testQuit]
     ]

--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import qualified Test.Framework as Test
+import Database.Redis
+import Tests
+
+main :: IO ()
+main = do
+    -- We're looking for the cluster on a non-default port to support running
+    -- this test in parallel witht the regular non-cluster tests. To quickly
+    -- spin up a cluster on this port using docker you can run:
+    --
+    --     docker run -e "IP=0.0.0.0" -p 7000-7010:7000-7010 grokzen/redis-cluster:5.0.6
+    conn <- connectCluster defaultConnectInfo { connectPort = PortNumber 7000 }
+    Test.defaultMain (tests conn)
+
+tests :: Connection -> [Test.Test]
+tests conn = map ($conn) $ concat
+    [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
+    , testsZSets, [testTransaction], [testScripting]
+    , testsConnection, testsServer, [testZrangelex]
+      -- should always be run last as connection gets closed after it
+    , [testQuit]
+    ]
+
+testsServer :: [Test]
+testsServer =
+    [testBgrewriteaof, testFlushall, testSlowlog, testDebugObject]
+
+testsConnection :: [Test]
+testsConnection = [ testConnectAuthUnexpected, testConnectDb
+                  , testConnectDbUnexisting, testEcho, testPing
+                  ]
+
+testsKeys :: [Test]
+testsKeys = [ testKeys, testExpireAt, testSortCluster, testGetType, testObject ]
+
+testSortCluster :: Test
+testSortCluster = testCase "sort" $ do
+    lpush "{same}ids"     ["1","2","3"]                      >>=? 3
+    sort "{same}ids" defaultSortOpts                         >>=? ["1","2","3"]
+    sortStore "{same}ids" "{same}anotherKey" defaultSortOpts >>=? 3
+    let opts = defaultSortOpts { sortOrder = Desc, sortAlpha = True
+                               , sortLimit = (1,2)
+                               , sortBy    = Nothing
+                               , sortGet   = [] }
+    sort "{same}ids" opts >>=? ["2", "1"]

--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -21,7 +21,7 @@ tests :: Connection -> [Test.Test]
 tests conn = map ($conn) $ concat
     [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
     , testsZSets, [testTransaction], [testScripting]
-    , testsConnection, testsServer, [testZrangelex]
+    , testsConnection, testsServer, [testSScan, testHScan, testZScan], [testZrangelex]
       -- should always be run last as connection gets closed after it
     , [testQuit]
     ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,34 @@
+module Main (main) where
+
+import qualified Test.Framework as Test
+import Database.Redis
+import Tests
+import PubSubTest
+
+main :: IO ()
+main = do
+    conn <- connect defaultConnectInfo
+    Test.defaultMain (tests conn)
+
+tests :: Connection -> [Test.Test]
+tests conn = map ($conn) $ concat
+    [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
+    , testsZSets, [testPubSub], [testTransaction], [testScripting]
+    , testsConnection, testsServer, [testScans, testSScan, testHScan, testZScan], [testZrangelex]
+    , [testXAddRead, testXReadGroup, testXRange, testXpending, testXClaim, testXInfo, testXDel, testXTrim]
+    , testPubSubThreaded
+      -- should always be run last as connection gets closed after it
+    , [testQuit]
+    ]
+
+testsServer :: [Test]
+testsServer =
+    [testServer, testBgrewriteaof, testFlushall, testInfo, testConfig
+    ,testSlowlog, testDebugObject]
+
+testsConnection :: [Test]
+testsConnection = [ testConnectAuth, testConnectAuthUnexpected, testConnectDb
+                  , testConnectDbUnexisting, testEcho, testPing, testSelect ]
+
+testsKeys :: [Test]
+testsKeys = [ testKeys, testKeysNoncluster, testExpireAt, testSort, testGetType, testObject ]

--- a/test/PubSubTest.hs
+++ b/test/PubSubTest.hs
@@ -70,35 +70,34 @@ removeAllTest conn = Test.testCase "Multithreaded Pub/Sub - basic" $ do
   ctrl <- newPubSubController [("foo1", handler "InitialFoo1" msgVar), ("foo2", handler "InitialFoo2" msgVar)]
                               [("bar1:*", phandler "InitialBar1" msgVar), ("bar2:*", phandler "InitialBar2" msgVar)]
   withAsync (pubSubForever conn ctrl (atomically $ writeTVar initialComplete True)) $ \_ -> do
+    -- wait for initial
+    atomically $ readTVar initialComplete >>= \b -> if b then return () else retry
+    expectRedisChannels conn ["foo1", "foo2"]
 
-  -- wait for initial
-  atomically $ readTVar initialComplete >>= \b -> if b then return () else retry
-  expectRedisChannels conn ["foo1", "foo2"]
+    runRedis conn $ publish "foo1" "Hello"
+    waitForMessage msgVar "InitialFoo1" "Hello"
 
-  runRedis conn $ publish "foo1" "Hello"
-  waitForMessage msgVar "InitialFoo1" "Hello"
+    runRedis conn $ publish "bar2:zzz" "World"
+    waitForPMessage msgVar "InitialBar2" "bar2:zzz" "World"
 
-  runRedis conn $ publish "bar2:zzz" "World"
-  waitForPMessage msgVar "InitialBar2" "bar2:zzz" "World"
+    -- subscribe to foo1 and bar1 again
+    addChannelsAndWait ctrl [("foo1", handler "NewFoo1" msgVar)] [("bar1:*", phandler "NewBar1" msgVar)]
+    expectRedisChannels conn ["foo1", "foo2"]
 
-  -- subscribe to foo1 and bar1 again
-  addChannelsAndWait ctrl [("foo1", handler "NewFoo1" msgVar)] [("bar1:*", phandler "NewBar1" msgVar)]
-  expectRedisChannels conn ["foo1", "foo2"]
+    runRedis conn $ publish "foo1" "abcdef"
+    waitForMessage msgVar "InitialFoo1" "abcdef"
+    waitForMessage msgVar "NewFoo1" "abcdef"
 
-  runRedis conn $ publish "foo1" "abcdef"
-  waitForMessage msgVar "InitialFoo1" "abcdef"
-  waitForMessage msgVar "NewFoo1" "abcdef"
+    -- unsubscribe from foo1 and bar1
+    removeChannelsAndWait ctrl ["foo1", "unusued"] ["bar1:*", "unused:*"]
+    expectRedisChannels conn ["foo2"]
 
-  -- unsubscribe from foo1 and bar1
-  removeChannelsAndWait ctrl ["foo1", "unusued"] ["bar1:*", "unused:*"]
-  expectRedisChannels conn ["foo2"]
+    -- foo2 and bar2 are still subscribed
+    runRedis conn $ publish "foo2" "12345"
+    waitForMessage msgVar "InitialFoo2" "12345"
 
-  -- foo2 and bar2 are still subscribed
-  runRedis conn $ publish "foo2" "12345"
-  waitForMessage msgVar "InitialFoo2" "12345"
-
-  runRedis conn $ publish "bar2:aaa" "0987"
-  waitForPMessage msgVar "InitialBar2" "bar2:aaa" "0987"
+    runRedis conn $ publish "bar2:aaa" "0987"
+    waitForPMessage msgVar "InitialBar2" "bar2:aaa" "0987"
 
 data TestError = TestError ByteString
   deriving (Eq, Show, Typeable)
@@ -127,48 +126,48 @@ removeFromUnregister conn = Test.testCase "Multithreaded Pub/Sub - unregister ha
   initialComplete <- newTVarIO False
   ctrl <- newPubSubController [] []
   withAsync (pubSubForever conn ctrl (atomically $ writeTVar initialComplete True)) $ \_ -> do
-  atomically $ readTVar initialComplete >>= \b -> if b then return () else retry
+    atomically $ readTVar initialComplete >>= \b -> if b then return () else retry
 
-  -- register to some channels
-  void $ addChannelsAndWait ctrl
-      [("abc", handler "InitialAbc" msgVar), ("xyz", handler "InitialXyz" msgVar)]
-      [("def:*", phandler "InitialDef" msgVar), ("uvw", phandler "InitialUvw" msgVar)]
-  expectRedisChannels conn ["abc", "xyz"]
+    -- register to some channels
+    void $ addChannelsAndWait ctrl
+        [("abc", handler "InitialAbc" msgVar), ("xyz", handler "InitialXyz" msgVar)]
+        [("def:*", phandler "InitialDef" msgVar), ("uvw", phandler "InitialUvw" msgVar)]
+    expectRedisChannels conn ["abc", "xyz"]
 
-  runRedis conn $ publish "abc" "Hello"
-  waitForMessage msgVar "InitialAbc" "Hello"
+    runRedis conn $ publish "abc" "Hello"
+    waitForMessage msgVar "InitialAbc" "Hello"
 
-  -- register to some more channels
-  unreg <- addChannelsAndWait ctrl
-      [("abc", handler "SecondAbc"  msgVar), ("123", handler "Second123" msgVar)]
-      [("def:*", phandler "SecondDef" msgVar), ("890:*", phandler "Second890" msgVar)]
-  expectRedisChannels conn ["abc", "xyz", "123"]
+    -- register to some more channels
+    unreg <- addChannelsAndWait ctrl
+        [("abc", handler "SecondAbc"  msgVar), ("123", handler "Second123" msgVar)]
+        [("def:*", phandler "SecondDef" msgVar), ("890:*", phandler "Second890" msgVar)]
+    expectRedisChannels conn ["abc", "xyz", "123"]
 
-  -- check messages on all channels
-  runRedis conn $ publish "abc" "World"
-  waitForMessage msgVar "InitialAbc" "World"
-  waitForMessage msgVar "SecondAbc" "World"
+    -- check messages on all channels
+    runRedis conn $ publish "abc" "World"
+    waitForMessage msgVar "InitialAbc" "World"
+    waitForMessage msgVar "SecondAbc" "World"
 
-  runRedis conn $ publish "123" "World2"
-  waitForMessage msgVar "Second123" "World2"
+    runRedis conn $ publish "123" "World2"
+    waitForMessage msgVar "Second123" "World2"
 
-  runRedis conn $ publish "def:bbbb" "World3"
-  waitForPMessage msgVar "InitialDef" "def:bbbb" "World3"
-  waitForPMessage msgVar "SecondDef" "def:bbbb" "World3"
+    runRedis conn $ publish "def:bbbb" "World3"
+    waitForPMessage msgVar "InitialDef" "def:bbbb" "World3"
+    waitForPMessage msgVar "SecondDef" "def:bbbb" "World3"
 
-  runRedis conn $ publish "890:tttt" "World4"
-  waitForPMessage msgVar "Second890" "890:tttt" "World4"
+    runRedis conn $ publish "890:tttt" "World4"
+    waitForPMessage msgVar "Second890" "890:tttt" "World4"
 
-  -- unregister
-  unreg
+    -- unregister
+    unreg
 
-  -- we have no way of waiting until unregister actually happened, so just delay and hope
-  threadDelay $ 1000*1000 -- 1 second
-  expectRedisChannels conn ["abc", "xyz"]
+    -- we have no way of waiting until unregister actually happened, so just delay and hope
+    threadDelay $ 1000*1000 -- 1 second
+    expectRedisChannels conn ["abc", "xyz"]
 
-  -- now only initial should be around. In particular, abc should still be subscribed
-  runRedis conn $ publish "abc" "World5"
-  waitForMessage msgVar "InitialAbc" "World5"
+    -- now only initial should be around. In particular, abc should still be subscribed
+    runRedis conn $ publish "abc" "World5"
+    waitForMessage msgVar "InitialAbc" "World5"
 
-  runRedis conn $ publish "def:cccc" "World6"
-  waitForPMessage msgVar "InitialDef" "def:cccc" "World6"
+    runRedis conn $ publish "def:cccc" "World6"
+    waitForPMessage msgVar "InitialDef" "def:cccc" "World6"

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -178,7 +178,7 @@ testGetType = testCase "getType" $ do
         del ["key"]   >>=? 1
   where
     ts = [ (set "key" "value"                         >>=? Ok,   String)
-         , (hset "key" "field" "value"                >>=? True, Hash)
+         , (hset "key" "field" "value"                >>=? 1,    Hash)
          , (lpush "key" ["value"]                     >>=? 1,    List)
          , (sadd "key" ["member"]                     >>=? 1,    Set)
          , (zadd "key" [(42,"member"),(12.3,"value")] >>=? 2,    ZSet)
@@ -237,7 +237,9 @@ testBitops = testCase "bitops" $ do
 --
 testHashes :: Test
 testHashes = testCase "hashes" $ do
-    hset "key" "field" "value"   >>=? True
+    hset "key" "field" "another" >>=? 1
+    hset "key" "field" "another" >>=? 0
+    hset "key" "field" "value"   >>=? 0
     hsetnx "key" "field" "value" >>=? False
     hexists "key" "field"        >>=? True
     hlen "key"                   >>=? 1
@@ -615,7 +617,7 @@ testSScan = testCase "sscan" $ do
 
 testHScan :: Test
 testHScan = testCase "hscan" $ do
-    hset "hash" "k" "v"     >>=? True
+    hset "hash" "k" "v"     >>=? 1
     hscan "hash" cursor0    >>=? (cursor0, [("k", "v")])
 
 testZScan :: Test

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -605,14 +605,23 @@ testScans = testCase "scans" $ do
     scan cursor0            >>=? (cursor0, ["key"])
     scanOpts cursor0 sOpts1 >>=? (cursor0, ["key"])
     scanOpts cursor0 sOpts2 >>=? (cursor0, [])
-    sadd "set" ["1"]        >>=? 1
-    sscan "set" cursor0     >>=? (cursor0, ["1"])
-    hset "hash" "k" "v"     >>=? True
-    hscan "hash" cursor0    >>=? (cursor0, [("k", "v")])
-    zadd "zset" [(42, "2")] >>=? 1
-    zscan "zset" cursor0    >>=? (cursor0, [("2", 42)])
     where sOpts1 = defaultScanOpts { scanMatch = Just "k*" }
           sOpts2 = defaultScanOpts { scanMatch = Just "not*"}
+
+testSScan :: Test
+testSScan = testCase "sscan" $ do
+    sadd "set" ["1"]        >>=? 1
+    sscan "set" cursor0     >>=? (cursor0, ["1"])
+
+testHScan :: Test
+testHScan = testCase "hscan" $ do
+    hset "hash" "k" "v"     >>=? True
+    hscan "hash" cursor0    >>=? (cursor0, [("k", "v")])
+
+testZScan :: Test
+testZScan = testCase "zscan" $ do
+    zadd "zset" [(42, "2")] >>=? 1
+    zscan "zset" cursor0    >>=? (cursor0, [("2", 42)])
 
 testZrangelex ::Test
 testZrangelex = testCase "zrangebylex" $ do

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -634,20 +634,20 @@ testZrangelex = testCase "zrangebylex" $ do
 
 testXAddRead ::Test
 testXAddRead = testCase "xadd/xread" $ do
-    xadd "somestream" "123" [("key", "value"), ("key2", "value2")]
-    xadd "otherstream" "456" [("key1", "value1")]
-    xaddOpts "thirdstream" "*" [("k", "v")] (Maxlen 1)
-    xaddOpts "thirdstream" "*" [("k", "v")] (ApproxMaxlen 1)
-    xread [("somestream", "0"), ("otherstream", "0")] >>=? Just [
+    xadd "{same}somestream" "123" [("key", "value"), ("key2", "value2")]
+    xadd "{same}otherstream" "456" [("key1", "value1")]
+    xaddOpts "{same}thirdstream" "*" [("k", "v")] (Maxlen 1)
+    xaddOpts "{same}thirdstream" "*" [("k", "v")] (ApproxMaxlen 1)
+    xread [("{same}somestream", "0"), ("{same}otherstream", "0")] >>=? Just [
         XReadResponse {
-            stream = "somestream",
+            stream = "{same}somestream",
             records = [StreamsRecord{recordId = "123-0", keyValues = [("key", "value"), ("key2", "value2")]}]
         },
         XReadResponse {
-            stream = "otherstream",
+            stream = "{same}otherstream",
             records = [StreamsRecord{recordId = "456-0", keyValues = [("key1", "value1")]}]
         }]
-    xlen "somestream" >>=? 1
+    xlen "{same}somestream" >>=? 1
 
 testXReadGroup ::Test
 testXReadGroup = testCase "XGROUP */xreadgroup/xack" $ do

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP, OverloadedStrings, RecordWildCards, LambdaCase #-}
-module Main (main) where
+module Tests where
 
 #if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
@@ -13,21 +13,15 @@ import Control.Monad.Trans
 import qualified Data.List as L
 import Data.Time
 import Data.Time.Clock.POSIX
-import qualified Test.Framework as Test (Test, defaultMain)
+import qualified Test.Framework as Test (Test)
 import qualified Test.Framework.Providers.HUnit as Test (testCase)
 import qualified Test.HUnit as HUnit
 
 import Database.Redis
-import PubSubTest
 
 ------------------------------------------------------------------------------
--- Main and helpers
+-- helpers
 --
-main :: IO ()
-main = do
-    conn <- connect defaultConnectInfo
-    Test.defaultMain (tests conn)
-
 type Test = Connection -> Test.Test
 
 testCase :: String -> Redis () -> Test
@@ -50,20 +44,6 @@ redis >>=? expected = do
 
 assert :: Bool -> Redis ()
 assert = liftIO . HUnit.assert
-
-------------------------------------------------------------------------------
--- Tests
---
-tests :: Connection -> [Test.Test]
-tests conn = map ($conn) $ concat
-    [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
-    , testsZSets, [testPubSub], [testTransaction], [testScripting]
-    , testsConnection, testsServer, [testScans], [testZrangelex]
-    , [testXAddRead, testXReadGroup, testXRange, testXpending, testXClaim, testXInfo, testXDel, testXTrim]
-    , testPubSubThreaded
-      -- should always be run last as connection gets closed after it
-    , [testQuit]
-    ]
 
 ------------------------------------------------------------------------------
 -- Miscellaneous
@@ -113,49 +93,51 @@ testEvalReplies :: Test
 testEvalReplies conn = testCase "eval unused replies" go conn
   where
     go = do
-      _ignored <- set "key" "value"
-      (liftIO $ do
+      _ <- liftIO $ runRedis conn $ set "key" "value"
+      result <- liftIO $ do
          threadDelay $ 10 ^ (5 :: Int)
          mvar <- newEmptyMVar
          _ <-
            (Async.wait =<< Async.async (runRedis conn (get "key"))) >>= putMVar mvar
-         takeMVar mvar) >>=?
-        Just "value"
+         takeMVar mvar
+      pure result >>=? Just "value"
 
 ------------------------------------------------------------------------------
 -- Keys
 --
-testsKeys :: [Test]
-testsKeys = [ testKeys, testExpireAt, testSort, testGetType, testObject ]
-
 testKeys :: Test
 testKeys = testCase "keys" $ do
+    set "{same}key" "value"     >>=? Ok
+    get "{same}key"             >>=? Just "value"
+    exists "{same}key"          >>=? True
+    expire "{same}key" 1        >>=? True
+    pexpire "{same}key" 1000    >>=? True
+    ttl "{same}key" >>= \case
+      Left _ -> error "error"
+      Right t -> do
+        assert $ t `elem` [0..1]
+        pttl "{same}key" >>= \case
+          Left _ -> error "error"
+          Right pt -> do
+            assert $ pt `elem` [990..1000]
+            persist "{same}key"         >>=? True
+            dump "{same}key" >>= \case
+              Left _ -> error "impossible"
+              Right s -> do
+                restore "{same}key'" 0 s          >>=? Ok
+                rename "{same}key" "{same}key'"   >>=? Ok
+                renamenx "{same}key'" "{same}key" >>=? True
+                del ["{same}key"]                 >>=? 1
+
+testKeysNoncluster :: Test
+testKeysNoncluster = testCase "keysNoncluster" $ do
     set "key" "value"     >>=? Ok
-    get "key"             >>=? Just "value"
-    exists "key"          >>=? True
     keys "*"              >>=? ["key"]
     randomkey             >>=? Just "key"
     move "key" 13         >>=? True
     select 13             >>=? Ok
-    expire "key" 1        >>=? True
-    pexpire "key" 1000    >>=? True
-    ttl "key" >>= \case
-      Left _ -> error "error"
-      Right t -> do
-        assert $ t `elem` [0..1]
-        pttl "key" >>= \case
-          Left _ -> error "error"
-          Right pt -> do
-            assert $ pt `elem` [990..1000]
-            persist "key"         >>=? True
-            dump "key" >>= \case
-              Left _ -> error "impossible"
-              Right s -> do
-                restore "key'" 0 s    >>=? Ok
-                rename "key" "key'"   >>=? Ok
-                renamenx "key'" "key" >>=? True
-                del ["key"]           >>=? 1
-                select 0              >>=? Ok
+    get "key"             >>=? Just "value"
+    select 0              >>=? Ok
 
 testExpireAt :: Test
 testExpireAt = testCase "expireat" $ do
@@ -219,36 +201,36 @@ testsStrings = [testStrings, testBitops]
 
 testStrings :: Test
 testStrings = testCase "strings" $ do
-    setnx "key" "value"               >>=? True
-    getset "key" "hello"              >>=? Just "value"
-    append "key" "world"              >>=? 10
-    strlen "key"                      >>=? 10
-    setrange "key" 0 "hello"          >>=? 10
-    getrange "key" 0 4                >>=? "hello"
-    mset [("k1","v1"), ("k2","v2")]   >>=? Ok
-    msetnx [("k1","v1"), ("k2","v2")] >>=? False
-    mget ["key"]                      >>=? [Just "helloworld"]
-    setex "key" 1 "42"                >>=? Ok
-    psetex "key" 1000 "42"            >>=? Ok
-    decr "key"                        >>=? 41
-    decrby "key" 1                    >>=? 40
-    incr "key"                        >>=? 41
-    incrby "key" 1                    >>=? 42
-    incrbyfloat "key" 1               >>=? 43
-    del ["key"]                       >>=? 1
-    setbit "key" 42 "1"               >>=? 0
-    getbit "key" 42                   >>=? 1
-    bitcount "key"                    >>=? 1
-    bitcountRange "key" 0 (-1)        >>=? 1
+    setnx "key" "value"                           >>=? True
+    getset "key" "hello"                          >>=? Just "value"
+    append "key" "world"                          >>=? 10
+    strlen "key"                                  >>=? 10
+    setrange "key" 0 "hello"                      >>=? 10
+    getrange "key" 0 4                            >>=? "hello"
+    mset [("{same}k1","v1"), ("{same}k2","v2")]   >>=? Ok
+    msetnx [("{same}k1","v1"), ("{same}k2","v2")] >>=? False
+    mget ["key"]                                  >>=? [Just "helloworld"]
+    setex "key" 1 "42"                            >>=? Ok
+    psetex "key" 1000 "42"                        >>=? Ok
+    decr "key"                                    >>=? 41
+    decrby "key" 1                                >>=? 40
+    incr "key"                                    >>=? 41
+    incrby "key" 1                                >>=? 42
+    incrbyfloat "key" 1                           >>=? 43
+    del ["key"]                                   >>=? 1
+    setbit "key" 42 "1"                           >>=? 0
+    getbit "key" 42                               >>=? 1
+    bitcount "key"                                >>=? 1
+    bitcountRange "key" 0 (-1)                    >>=? 1
 
 testBitops :: Test
 testBitops = testCase "bitops" $ do
-    set "k1" "a"               >>=? Ok
-    set "k2" "b"               >>=? Ok
-    bitopAnd "k3" ["k1", "k2"] >>=? 1
-    bitopOr "k3" ["k1", "k2"]  >>=? 1
-    bitopXor "k3" ["k1", "k2"] >>=? 1
-    bitopNot "k3" "k1"         >>=? 1
+    set "{same}k1" "a"                           >>=? Ok
+    set "{same}k2" "b"                           >>=? Ok
+    bitopAnd "{same}k3" ["{same}k1", "{same}k2"] >>=? 1
+    bitopOr "{same}k3" ["{same}k1", "{same}k2"]  >>=? 1
+    bitopXor "{same}k3" ["{same}k1", "{same}k2"] >>=? 1
+    bitopNot "{same}k3" "{same}k1"               >>=? 1
 
 ------------------------------------------------------------------------------
 -- Hashes
@@ -296,12 +278,12 @@ testLists = testCase "lists" $ do
 
 testBpop :: Test
 testBpop = testCase "blocking push/pop" $ do
-    lpush "key" ["v3","v2","v1"] >>=? 3
-    blpop ["key"] 1              >>=? Just ("key","v1")
-    brpop ["key"] 1              >>=? Just ("key","v3")
-    rpush "k1" ["v1","v2"]       >>=? 2
-    brpoplpush "k1" "k2" 1       >>=? Just "v2"
-    rpoplpush "k1" "k2"          >>=? Just "v1"
+    lpush "{same}key" ["v3","v2","v1"] >>=? 3
+    blpop ["{same}key"] 1              >>=? Just ("{same}key","v1")
+    brpop ["{same}key"] 1              >>=? Just ("{same}key","v3")
+    rpush "{same}k1" ["v1","v2"]       >>=? 2
+    brpoplpush "{same}k1" "{same}k2" 1 >>=? Just "v2"
+    rpoplpush "{same}k1" "{same}k2"    >>=? Just "v1"
 
 ------------------------------------------------------------------------------
 -- Sets
@@ -318,7 +300,7 @@ testSets = testCase "sets" $ do
     srandmember "set"           >>=? Just "member"
     spop "set"                  >>=? Just "member"
     srem "set" ["member"]       >>=? 0
-    smove "set" "set'" "member" >>=? False
+    smove "{same}set" "{same}set'" "member" >>=? False
     _ <- sadd "set" ["member1", "member2"]
     (fmap L.sort <$> spopN "set" 2) >>=? ["member1", "member2"]
     _ <- sadd "set" ["member1", "member2"]
@@ -326,13 +308,13 @@ testSets = testCase "sets" $ do
 
 testSetAlgebra :: Test
 testSetAlgebra = testCase "set algebra" $ do
-    sadd "s1" ["member"]          >>=? 1
-    sdiff ["s1", "s2"]            >>=? ["member"]
-    sunion ["s1", "s2"]           >>=? ["member"]
-    sinter ["s1", "s2"]           >>=? []
-    sdiffstore "s3" ["s1", "s2"]  >>=? 1
-    sunionstore "s3" ["s1", "s2"] >>=? 1
-    sinterstore "s3" ["s1", "s2"] >>=? 0
+    sadd "{same}s1" ["member"]                      >>=? 1
+    sdiff ["{same}s1", "{same}s2"]                  >>=? ["member"]
+    sunion ["{same}s1", "{same}s2"]                 >>=? ["member"]
+    sinter ["{same}s1", "{same}s2"]                 >>=? []
+    sdiffstore "{same}s3" ["{same}s1", "{same}s2"]  >>=? 1
+    sunionstore "{same}s3" ["{same}s1", "{same}s2"] >>=? 1
+    sinterstore "{same}s3" ["{same}s1", "{same}s2"] >>=? 0
 
 ------------------------------------------------------------------------------
 -- Sorted Sets
@@ -371,16 +353,16 @@ testZSets = testCase "sorted sets" $ do
 
 testZStore :: Test
 testZStore = testCase "zunionstore/zinterstore" $ do
-    zadd "k1" [(1, "v1"), (2, "v2")] >>= \case
+    zadd "{same}k1" [(1, "v1"), (2, "v2")] >>= \case
       Left _ -> error "error"
       _ -> return ()
-    zadd "k2" [(2, "v2"), (3, "v3")] >>= \case
+    zadd "{same}k2" [(2, "v2"), (3, "v3")] >>= \case
       Left _ -> error "error"
       _ -> return ()
-    zinterstore "newkey" ["k1","k2"] Sum                >>=? 1
-    zinterstoreWeights "newkey" [("k1",1),("k2",2)] Max >>=? 1
-    zunionstore "newkey" ["k1","k2"] Sum                >>=? 3
-    zunionstoreWeights "newkey" [("k1",1),("k2",2)] Min >>=? 3
+    zinterstore "{same}newkey" ["{same}k1","{same}k2"] Sum                >>=? 1
+    zinterstoreWeights "{same}newkey" [("{same}k1",1),("{same}k2",2)] Max >>=? 1
+    zunionstore "{same}newkey" ["{same}k1","{same}k2"] Sum                >>=? 3
+    zunionstoreWeights "{same}newkey" [("{same}k1",1),("{same}k2",2)] Min >>=? 3
 
 ------------------------------------------------------------------------------
 -- HyperLogLog
@@ -403,18 +385,18 @@ testHyperLogLog = testCase "hyperloglog" $ do
       _ -> return ()
   pfcount ["hll1"] >>=? 5
   -- test merge
-  pfadd "hll2" ["1", "2", "3"] >>= \case
+  pfadd "{same}hll2" ["1", "2", "3"] >>= \case
       Left _ -> error "error"
       _ -> return ()
-  pfadd "hll3" ["4", "5", "6"] >>= \case
+  pfadd "{same}hll3" ["4", "5", "6"] >>= \case
       Left _ -> error "error"
       _ -> return ()
-  pfmerge "hll4" ["hll2", "hll3"] >>= \case
+  pfmerge "{same}hll4" ["{same}hll2", "{same}hll3"] >>= \case
       Left _ -> error "error"
       _ -> return ()
-  pfcount ["hll4"] >>=? 6
+  pfcount ["{same}hll4"] >>=? 6
   -- test union cardinality
-  pfcount ["hll2", "hll3"] >>=? 6
+  pfcount ["{same}hll2", "{same}hll3"] >>=? 6
 
 ------------------------------------------------------------------------------
 -- Pub/Sub
@@ -452,17 +434,17 @@ testPubSub conn = testCase "pubSub" go conn
 --
 testTransaction :: Test
 testTransaction = testCase "transaction" $ do
-    watch ["k1", "k2"] >>=? Ok
+    watch ["{same}k1", "{same}k2"] >>=? Ok
     unwatch            >>=? Ok
-    set "foo" "foo" >>= \case
+    set "{same}foo" "foo" >>= \case
       Left _ -> error "error"
       _ -> return ()
-    set "bar" "bar" >>= \case
+    set "{same}bar" "bar" >>= \case
       Left _ -> error "error"
       _ -> return ()
     foobar <- multiExec $ do
-        foo <- get "foo"
-        bar <- get "bar"
+        foo <- get "{same}foo"
+        bar <- get "{same}bar"
         return $ (,) <$> foo <*> bar
     assert $ foobar == TxSuccess (Just "foo", Just "bar")
 
@@ -503,10 +485,6 @@ testScripting conn = testCase "scripting" go conn
 ------------------------------------------------------------------------------
 -- Connection
 --
-testsConnection :: [Test]
-testsConnection = [ testConnectAuth, testConnectAuthUnexpected, testConnectDb
-                  , testConnectDbUnexisting, testEcho, testPing, testSelect ]
-
 testConnectAuth :: Test
 testConnectAuth = testCase "connect/auth" $ do
     configSet "requirepass" "pass" >>=? Ok
@@ -563,11 +541,6 @@ testSelect = testCase "select" $ do
 ------------------------------------------------------------------------------
 -- Server
 --
-testsServer :: [Test]
-testsServer =
-    [testServer, testBgrewriteaof, testFlushall, testInfo, testConfig
-    ,testSlowlog, testDebugObject]
-
 testServer :: Test
 testServer = testCase "server" $ do
     time >>= \case

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -504,7 +504,7 @@ testConnectAuthUnexpected = testCase "connect/auth/unexpected" $ do
 
     where connInfo = defaultConnectInfo { connectAuth = Just "pass" }
           err = Left $ ConnectAuthError $
-                  Error "ERR Client sent AUTH, but no password is set"
+                  Error "ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?"
 
 testConnectDb :: Test
 testConnectDb = testCase "connect/db" $ do

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
+set -e
+
+echo "**These tests assume there is a redis server running on port 6379**"
 
 # The -M argument limits heap size for 'testConstantSpacePipelining'.
-cabal-dev test --test-options="+RTS -M3m"
+cabal exec cabal test doctest
+cabal test hedis-test --test-options="+RTS -M10m"
 
 echo "------------------"
 echo "hlint suggestions:"


### PR DESCRIPTION
This fixes an issue with key identification in variadic commands.

We noticed a problem using the `mset` command. It threw a `CrossSlotException`, but inspection showed the keys it was trying to set definitely all fell in the same hashslot. Upon looking closer we noticed that the values rather than the keys were used to determine whether the command was for a single hash slot.