### PR TITLE
Added Support for readonly enabled connection

### DIFF
--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -102,6 +102,13 @@ keysForRequest (InfoMap infoMap) request@(command:_) = do
         return $ takeEvery (fromEnum $ stepCount info) possibleKeys
 keysForRequest _ [] = Nothing
 
+isCommandReadonly :: InfoMap -> [BS.ByteString] -> Bool
+isCommandReadonly (InfoMap infoMap) (command: _) = 
+    let
+        info = HM.lookup (map toLower $ Char8.unpack command) infoMap
+    in maybe (False) (ReadOnly `elem`) (flags <$> info)
+isCommandReadonly _ _ = False
+
 isMovable :: CommandInfo -> Bool
 isMovable CommandInfo{..} = MovableKeys `elem` flags
 

--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -102,13 +102,6 @@ keysForRequest (InfoMap infoMap) request@(command:_) = do
         return $ takeEvery (fromEnum $ stepCount info) possibleKeys
 keysForRequest _ [] = Nothing
 
-isCommandReadonly :: InfoMap -> [BS.ByteString] -> Bool
-isCommandReadonly (InfoMap infoMap) (command: _) = 
-    let
-        info = HM.lookup (map toLower $ Char8.unpack command) infoMap
-    in maybe (False) (ReadOnly `elem`) (flags <$> info)
-isCommandReadonly _ _ = False
-
 isMovable :: CommandInfo -> Bool
 isMovable CommandInfo{..} = MovableKeys `elem` flags
 

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -274,7 +274,8 @@ clusterSetSlotStable,
 clusterSetSlotImporting,
 clusterSetSlotMigrating,
 clusterGetKeysInSlot,
-command
+command,
+readOnly
 -- * Unimplemented Commands
 -- |These commands are not implemented, as of now. Library
 --  users can implement these or other commands from

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -31,6 +31,7 @@ import Database.Redis.Commands
     , auth
     , clusterSlots
     , command
+    , readOnly
     , ClusterSlotsResponse(..)
     , ClusterSlotsResponseEntry(..)
     , ClusterSlotsNode(..))
@@ -61,6 +62,7 @@ data ConnectInfo = ConnInfo
     { connectHost           :: NS.HostName
     , connectPort           :: CC.PortID
     , connectAuth           :: Maybe B.ByteString
+    , connectReadOnly       :: Bool
     -- ^ When the server is protected by a password, set 'connectAuth' to 'Just'
     --   the password. Each connection will then authenticate by the 'auth'
     --   command.
@@ -106,6 +108,7 @@ defaultConnectInfo = ConnInfo
     { connectHost           = "localhost"
     , connectPort           = CC.PortNumber 6379
     , connectAuth           = Nothing
+    , connectReadOnly       = False
     , connectDatabase       = 0
     , connectMaxConnections = 50
     , connectMaxIdleTime    = 30
@@ -201,8 +204,27 @@ connectCluster bootstrapConnInfo = do
     case commandInfos of
         Left e -> throwIO $ ClusterConnectError e
         Right infos -> do
-            pool <- createPool (Cluster.connect infos shardMapVar Nothing) Cluster.disconnect 1 (connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo)
+            let 
+                isConnectionReadOnly = connectReadOnly bootstrapConnInfo
+                clusterConnection = Cluster.connect infos shardMapVar Nothing isConnectionReadOnly
+            pool <- createPool (clusterConnect isConnectionReadOnly clusterConnection) Cluster.disconnect 1 (connectMaxIdleTime bootstrapConnInfo) (connectMaxConnections bootstrapConnInfo)
             return $ ClusteredConnection shardMapVar pool
+    where
+        clusterConnect :: Bool -> IO Cluster.Connection -> IO Cluster.Connection
+        clusterConnect readOnlyConnection connection = do
+            clusterConn@(Cluster.Connection nodeMap _ _ _ _) <- connection
+            nodesConns <-  sequence $ ( PP.fromCtx . (\(Cluster.NodeConnection ctx _ _) -> ctx ) . snd) <$> (HM.toList nodeMap)
+            void $ if readOnlyConnection
+                then 
+                    mapM_ (\conn -> do
+                            PP.beginReceiving conn
+                            runRedisInternal conn readOnly
+                        ) nodesConns
+                else
+                    return ()
+            return clusterConn
+
+
 
 shardMapFromClusterSlotsResponse :: ClusterSlotsResponse -> IO ShardMap
 shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr mkShardMap (pure IntMap.empty)  clusterSlotsResponseEntries where
@@ -222,7 +244,7 @@ shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr m
             Cluster.Node clusterSlotsNodeID role hostname (toEnum clusterSlotsNodePort)
 
 refreshShardMap :: Cluster.Connection -> IO ShardMap
-refreshShardMap (Cluster.Connection nodeConns _ _ _) = do
+refreshShardMap (Cluster.Connection nodeConns _ _ _ _) = do
     let (Cluster.NodeConnection ctx _ _) = head $ HM.elems nodeConns
     pipelineConn <- PP.fromCtx ctx
     _ <- PP.beginReceiving pipelineConn

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -214,14 +214,11 @@ connectCluster bootstrapConnInfo = do
         clusterConnect readOnlyConnection connection = do
             clusterConn@(Cluster.Connection nodeMap _ _ _ _) <- connection
             nodesConns <-  sequence $ ( PP.fromCtx . (\(Cluster.NodeConnection ctx _ _) -> ctx ) . snd) <$> (HM.toList nodeMap)
-            void $ if readOnlyConnection
-                then 
+            when readOnlyConnection $
                     mapM_ (\conn -> do
                             PP.beginReceiving conn
                             runRedisInternal conn readOnly
                         ) nodesConns
-                else
-                    return ()
             return clusterConn
 
 

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -1378,3 +1378,7 @@ clusterGetKeysInSlot slot count = sendRequest ["CLUSTER", "GETKEYSINSLOT", (enco
 
 command :: (RedisCtx m f) => m (f [CMD.CommandInfo])
 command = sendRequest ["COMMAND"]
+
+readOnly :: (RedisCtx m f) => m (f Status)
+readOnly = sendRequest ["READONLY"]
+


### PR DESCRIPTION
Added Support for readonly enabled connection in redis Clusters.

The solution involves
-  having an extra field (boolean) in clusterConfig
- setting up a constructor in connection pool which after creating a connection, executes the redis "readonly" command to all the cluster nodes for that connection
- redirecting all "readonly" eligible commands to a slave if the clusterConfig has "readonly" bool set to True