### PR TITLE
Mobility/ghc-9.2.5 work for hedis

### DIFF
--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, RecordWildCards, FlexibleContexts #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 module Database.Redis.ManualCommands where
 

--- a/src/Database/Redis/ProtocolPipelining.hs
+++ b/src/Database/Redis/ProtocolPipelining.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -Wwarn=incomplete-uni-patterns #-}
 
 -- |A module for automatic, optimal protocol pipelining.
 --

--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -41,7 +41,7 @@ instance RedisCtx RedisTx Queued where
         -- future index in EXEC result list
         i <- get
         put (i+1)
-        return $ Queued (decode . (!i))
+        return $ Queued (decode . (! i))
 
 -- |A 'Queued' value represents the result of a command inside a transaction. It
 --  is a proxy object for the /actual/ result, which will only be available

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,1 +1,7 @@
-stack.yaml
+resolver: lts-15.15
+packages:
+  - '.'
+flags:
+  hedis:
+    dev: true
+extra-package-dbs: []

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -1,0 +1,10 @@
+resolver: lts-20.11
+allow-newer: true
+system-ghc: true
+
+packages:
+  - '.'
+flags:
+  hedis:
+    dev: true
+extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,1 @@
-resolver: lts-15.15
-packages:
-  - '.'
-flags:
-  hedis:
-    dev: true
-extra-package-dbs: []
+stack-9.2.yaml

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -55,7 +55,7 @@ assert = liftIO . HUnit.assert
 -- Tests
 --
 tests :: Connection -> [Test.Test]
-tests conn = map ($conn) $ concat
+tests conn = map ($ conn) $ concat
     [ testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
     , testsZSets, [testPubSub], [testTransaction], [testScripting]
     , testsConnection, testsServer, [testScans], [testZrangelex]


### PR DESCRIPTION
This PR enables the Repo to be built with newest lts stack resolver 20.11 which comes with new GHC version 9.2.5

This was a dependency to the Mobility set of projects and needed to be upgraded as a result of the upgrade efforts going on there.

This branch is not compatible with master (this is behind) because of the euler version the Mobility set of projects depends on at the moment. This branch therefore should remain as it's own thing and **not** be merged back into master for now.