### PR TITLE
Added retry logic for refreshShardMap

### DIFF
--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -121,7 +121,7 @@ instance Exception CrossSlotException
 data NoNodeException = NoNodeException  deriving (Show, Typeable)
 instance Exception NoNodeException
 
-connect :: (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> [CMD.CommandInfo] -> MVar ShardMap -> Maybe Int -> Bool -> (NodeConnection -> IO ShardMap) -> IO Connection
+connect :: (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> [CMD.CommandInfo] -> MVar ShardMap -> Maybe Int -> Bool -> ([NodeConnection] -> IO ShardMap) -> IO Connection
 connect withAuth commandInfos shardMapVar timeoutOpt isReadOnly refreshShardMap = do
         shardMap <- readMVar shardMapVar
         stateVar <- newMVar $ Pending []
@@ -134,7 +134,7 @@ connect withAuth commandInfos shardMapVar timeoutOpt isReadOnly refreshShardMap 
           if shouldRetry
             then if not (HM.null eNodeConns)
                     then do
-                      newShardMap <- refreshShardMap (head $ HM.elems eNodeConns)
+                      newShardMap <- refreshShardMap (HM.elems eNodeConns)
                       refreshShardMapVar newShardMap
                       simpleNodeConnections newShardMap
                     else


### PR DESCRIPTION
Issue : 
Currently we are only using the connection to the first node for refreshing shardMaps. In case the initial node itself is down, we won't be able to refresh the shardMap. 

Solution: 
Added a looping logic for traversing over all the nodes connections to handle the initial node failure case. 