### PR TITLE
Expose the connection types

### DIFF
--- a/src/Database/Redis.hs
+++ b/src/Database/Redis.hs
@@ -162,7 +162,7 @@ module Database.Redis (
     RedisCtx(..), MonadRedis(..),
 
     -- * Connection
-    Connection, ConnectError(..), connect, checkedConnect, disconnect,
+    Connection(..), ConnectError(..), connect, checkedConnect, disconnect,
     withConnect, withCheckedConnect,
     ConnectInfo(..), defaultConnectInfo, parseConnectInfo, connectCluster,
     PortID(..),


### PR DESCRIPTION
This PR exposes the types of redis connection `NonClusteredConnection` and `ClusteredConnection`. This is helpful to pattern match on connection type and perform different actions in different cases. 