### PR TITLE
Setup development environment with Nix Flakes.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,5 @@
 # Changelog for Hedis
 
-## 0.16.0
-* PR #31. Introduced Haskell Flakesi support in Hedis.
-
 ## 0.15.3
 * PR #27. Increased the default timeout for cluster connect, request node, and refresh Shard Map
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog for Hedis
 
+## 0.16.0
+* PR #31. Introduced Haskell Flakesi support in Hedis.
+
 ## 0.15.3
 * PR #27. Increased the default timeout for cluster connect, request node, and refresh Shard Map
 
@@ -272,3 +275,4 @@ Issue #136 fix slowlog parsing
   `zrank`, `zrevrank`, `zscore`.
 * Updated dependencies on `bytestring-lexing` and `stm`.
 * Minor improvements and fixes to the documentation.
+

--- a/README.md
+++ b/README.md
@@ -38,16 +38,24 @@ This library is written by Falko Peters <falko.peters@gmail.com>.
 Currently maintainer by Kostiantyn Rybnikov <k-bx@k-bx.com>.
 
 
-# Getting started
-  -- Development
-      -- Services
-          -- Redis: You can start a redis server using flakes.
-                    Run Command: `nix run .#redis-service`
-                    This will start a redis server in standalone and clustered modes in your system.
-      -- DevShell
-          -- nix develop
-  -- Build
-     -- nix build
+## Getting started
+### Development
+#### Services
+You can start a redis server using flakes.
+```
+nix run .#redis-service
+```
+This will start a redis server in standalone and clustered modes in your system.
+
+#### DevShell
+```
+nix develop
+```
+
+### Build
+```
+nix build
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,17 @@ Master [git repository](http://github.com/informatikr/hedis):
 This library is written by Falko Peters <falko.peters@gmail.com>.
 Currently maintainer by Kostiantyn Rybnikov <k-bx@k-bx.com>.
 
-# How to Start Redis Server Using Flakes.
 
-Use Below Command to start a redis server. It will start redis server both in cluster mode and standalone mode. 
+# Getting started
+  -- Development
+      -- Services
+          -- Redis: You can start a redis server using flakes.
+                    Run Command: `nix run .#redis-service`
+                    This will start a redis server in standalone and clustered modes in your system.
+      -- DevShell
+          -- nix develop
+  -- Build
+     -- nix build
 
-`nix run .#redis-service`
+
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ Master [git repository](http://github.com/informatikr/hedis):
 
 This library is written by Falko Peters <falko.peters@gmail.com>.
 Currently maintainer by Kostiantyn Rybnikov <k-bx@k-bx.com>.
+
+# How to Start Redis Server Using Flakes.
+
+Use Below Command to start a redis server. It will start redis server both in cluster mode and standalone mode. 
+
+`nix run .#redis-service`
+

--- a/flake.lock
+++ b/flake.lock
@@ -89,8 +89,7 @@
         "nixpkgs": "nixpkgs",
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
-        "system": "system",
-        "systems": "systems"
+        "system": "system"
       }
     },
     "services-flake": {
@@ -109,21 +108,6 @@
       }
     },
     "system": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,144 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "haskell-flake": {
+      "locked": {
+        "lastModified": 1700660308,
+        "narHash": "sha256-bn8c4qYpacgkm3r46dGGcj/uPu0luLPO3nsvfXFVKjQ=",
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "rev": "e1f6540334987310f47d02f7c89a16e3e1343e33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "haskell-flake",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700538105,
+        "narHash": "sha256-uZhOCmwv8VupEmPZm3erbr9XXmyg7K67Ul3+Rx2XMe0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "51a01a7e5515b469886c120e38db325c96694c2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "process-compose-flake": {
+      "locked": {
+        "lastModified": 1700692768,
+        "narHash": "sha256-3gUsXY0IEC1YHDFr5BeVgB2e7ln15pxtYRNvWTnZa4M=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "3eb125f614c0c17efda8e59ed53cd103bc474f92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "haskell-flake": "haskell-flake",
+        "nixpkgs": "nixpkgs",
+        "process-compose-flake": "process-compose-flake",
+        "services-flake": "services-flake",
+        "system": "system",
+        "systems": "systems"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1700680839,
+        "narHash": "sha256-IQTHVwptaz498nUo7QcbrgPukQgwUbYMuUM9QbEZBDw=",
+        "owner": "juspay",
+        "repo": "services-flake",
+        "rev": "48cd3d06c918b8104f47a5bfa27519652b93ecbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "services-flake",
+        "type": "github"
+      }
+    },
+    "system": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+      nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+      flake-parts.url = "github:hercules-ci/flake-parts";
+      haskell-flake.url = "github:srid/haskell-flake"; system.url = "github:nix-systems/default";
+      services-flake.url = "github:juspay/services-flake";
+      systems.url = "github:nix-systems/default";
+      process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ...}:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import inputs.system;
+      imports = [
+        inputs.haskell-flake.flakeModule
+        inputs.process-compose-flake.flakeModule
+        ];
+      perSystem = { self', pkgs, config, ...}: {
+        
+        process-compose.redis-service = { config, ...}: {
+           imports = [
+                inputs.services-flake.processComposeModules.default
+           ];
+            services.redis-cluster."cluster1".enable = true;
+            services.redis."redis".enable = true;
+       };
+        haskellProjects.default = {
+          basePackages = pkgs.haskell.packages.ghc947;
+          autoWire = [ "packages" ];
+        };
+        packages.default = self'.packages.hedis;
+        devShells.default = pkgs.mkShell {
+          name = "hedis";
+          inputsFrom = [
+            config.haskellProjects.default.outputs.devShell
+          ];
+        };
+      };
+    };
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,28 +1,30 @@
 {
   inputs = {
-      nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-      flake-parts.url = "github:hercules-ci/flake-parts";
-      haskell-flake.url = "github:srid/haskell-flake"; system.url = "github:nix-systems/default";
-      services-flake.url = "github:juspay/services-flake";
-      systems.url = "github:nix-systems/default";
-      process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
-    };
-  outputs = inputs@{ self, nixpkgs, flake-parts, ...}:
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    haskell-flake.url = "github:srid/haskell-flake";
+    system.url = "github:nix-systems/default";
+    services-flake.url = "github:juspay/services-flake";
+    systems.url = "github:nix-systems/default";
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+  };
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = import inputs.system;
       imports = [
         inputs.haskell-flake.flakeModule
         inputs.process-compose-flake.flakeModule
-        ];
-      perSystem = { self', pkgs, config, ...}: {
-        
-        process-compose.redis-service = { config, ...}: {
-           imports = [
-                inputs.services-flake.processComposeModules.default
-           ];
-            services.redis-cluster."cluster1".enable = true;
-            services.redis."redis".enable = true;
-       };
+      ];
+      perSystem = { self', pkgs, config, ... }: {
+
+        formatter = pkgs.nixpkgs-fmt;
+        process-compose.redis-service = { config, ... }: {
+          imports = [
+            inputs.services-flake.processComposeModules.default
+          ];
+          services.redis-cluster."cluster1".enable = true;
+          services.redis."redis".enable = true;
+        };
         haskellProjects.default = {
           basePackages = pkgs.haskell.packages.ghc947;
           autoWire = [ "packages" ];

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     haskell-flake.url = "github:srid/haskell-flake";
     system.url = "github:nix-systems/default";
     services-flake.url = "github:juspay/services-flake";
-    systems.url = "github:nix-systems/default";
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
   };
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:


### PR DESCRIPTION
Hedis Library doesn't have support for Haskell-Flakes. Added a flake.nix file which will add support for this. 

Using flakes we can start redis services in both standalone mode and clustered mode.