### PR TITLE
Added retry in refreshShardMapWithNodeConn and handled MULTI MOVED in…

### DIFF
--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -407,7 +407,7 @@ nodeConnForHashSlot shardMapVar conn errInfo hashSlot = do
             Nothing -> throwIO $ MissingNodeException ("HashSlot lookup failed in nodeConnForHashSlot" : errInfo)
             Just (Shard master _) -> return master
     case HM.lookup (nodeId node) nodeConns of
-        Nothing -> throwIO $ MissingNodeException ("NodeId lookup failed in nodeConnectionForCommand" : errInfo)
+        Nothing -> throwIO $ MissingNodeException ("NodeId lookup failed in nodeConnForHashSlot" : errInfo)
         Just nodeConn' -> return nodeConn'
 
 hashSlotForKeys :: Exception e => e -> [B.ByteString] -> IO HashSlot

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -34,7 +34,7 @@ import Data.Map(fromListWith, assocs)
 import Data.Function(on)
 import Control.Exception(Exception, SomeException, throwIO, BlockedIndefinitelyOnMVar(..), catches, Handler(..), try, fromException)
 import Control.Concurrent.MVar(MVar, newMVar, readMVar, modifyMVar, modifyMVar_)
-import Control.Monad(zipWithM, when, replicateM)
+import Control.Monad(zipWithM, when, replicateM, msum)
 import Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot)
 import qualified Database.Redis.ConnectionContext as CC
 import qualified Data.HashMap.Strict as HM
@@ -186,21 +186,21 @@ disconnect (Connection nodeConnsMvar _ _ _ _ ) = do
 -- Add a request to the current pipeline for this connection. The pipeline will
 -- be executed implicitly as soon as any result returned from this function is
 -- evaluated.
-requestPipelined :: IO ShardMap -> Connection -> [B.ByteString] -> IO Reply
-requestPipelined refreshAction conn@(Connection _ pipelineVar shardMapVar _ _) nextRequest = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
+requestPipelined :: IO ShardMap -> Connection -> [B.ByteString] -> (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> IO Reply
+requestPipelined refreshAction conn@(Connection _ pipelineVar shardMapVar _ _) nextRequest withAuth = modifyMVar pipelineVar $ \(Pipeline stateVar) -> do
     (newStateVar, repliesIndex) <- hasLocked $ modifyMVar stateVar $ \case
         Pending requests | isMulti nextRequest -> do
-            replies <- evaluatePipeline shardMapVar refreshAction conn requests
+            replies <- evaluatePipeline shardMapVar refreshAction conn requests withAuth
             s' <- newMVar $ TransactionPending [nextRequest]
             return (Executed replies, (s', 0))
         Pending requests | length requests > 1000 -> do
-            replies <- evaluatePipeline shardMapVar refreshAction conn (nextRequest:requests)
+            replies <- evaluatePipeline shardMapVar refreshAction conn (nextRequest:requests) withAuth
             return (Executed replies, (stateVar, length requests))
         Pending requests ->
             return (Pending (nextRequest:requests), (stateVar, length requests))
         TransactionPending requests ->
             if isExec nextRequest then do
-              replies <- evaluateTransactionPipeline shardMapVar refreshAction conn (nextRequest:requests)
+              replies <- evaluateTransactionPipeline shardMapVar refreshAction conn (nextRequest:requests) withAuth
               return (Executed replies, (stateVar, length requests))
             else
               return (TransactionPending (nextRequest:requests), (stateVar, length requests))
@@ -216,10 +216,10 @@ requestPipelined refreshAction conn@(Connection _ pipelineVar shardMapVar _ _) n
             Executed replies ->
                 return (Executed replies, replies)
             Pending requests-> do
-                replies <- evaluatePipeline shardMapVar refreshAction conn requests
+                replies <- evaluatePipeline shardMapVar refreshAction conn requests withAuth
                 return (Executed replies, replies)
             TransactionPending requests-> do
-                replies <- evaluateTransactionPipeline shardMapVar refreshAction conn requests
+                replies <- evaluateTransactionPipeline shardMapVar refreshAction conn requests withAuth
                 return (Executed replies, replies)
         return $ replies !! repliesIndex
     return (Pipeline newStateVar, evaluateAction)
@@ -255,8 +255,8 @@ rawResponse (CompletedRequest _ _ r) = r
 -- step is not pipelined, there is a request per error. This is probably
 -- acceptable in most cases as these errors should only occur in the case of
 -- cluster reconfiguration events, which should be rare.
-evaluatePipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> IO [Reply]
-evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
+evaluatePipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> IO [Reply]
+evaluatePipeline shardMapVar refreshShardmapAction conn requests withAuth = do
         shardMap <- hasLocked $ readMVar shardMapVar
         erequestsByNode <- try $ getRequestsByNode shardMap
         requestsByNode <- case erequestsByNode of
@@ -288,7 +288,7 @@ evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
             ) (zip eresps requestsByNode)
         -- check for any moved in both responses and continue the flow.
         when (any (moved . rawResponse) resps) refreshShardMapVar
-        retriedResps <- mapM (retry 0) resps
+        retriedResps <- mapM retry resps
         return $ map rawResponse $ sortBy (on compare responseIndex) retriedResps
   where
     getRequestsByNode :: ShardMap -> IO [(NodeConnection, [PendingRequest])]
@@ -303,9 +303,9 @@ evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
     executeRequests nodeConn nodeRequests = do
         replies <- requestNode nodeConn $ map rawRequest nodeRequests
         return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
-    retry :: Int -> CompletedRequest -> IO CompletedRequest
-    retry retryCount (CompletedRequest index request thisReply) = do
-        retryReply <- head <$> retryBatch shardMapVar refreshShardmapAction conn retryCount [request] [thisReply]
+    retry :: CompletedRequest -> IO CompletedRequest
+    retry (CompletedRequest index request thisReply) = do
+        retryReply <- head <$> retryBatch shardMapVar conn [request] [thisReply] withAuth
         return (CompletedRequest index request retryReply)
     refreshShardMapVar :: IO ()
     refreshShardMapVar = hasLocked $ modifyMVar_ shardMapVar (const refreshShardmapAction)
@@ -313,33 +313,36 @@ evaluatePipeline shardMapVar refreshShardmapAction conn requests = do
 -- Retry a batch of requests if any of the responses is a redirect instruction.
 -- If multiple requests are passed in they're assumed to be a MULTI..EXEC
 -- transaction and will all be retried.
-retryBatch :: MVar ShardMap -> IO ShardMap -> Connection -> Int -> [[B.ByteString]] -> [Reply] -> IO [Reply]
-retryBatch shardMapVar refreshShardmapAction conn retryCount requests replies =
-    -- The last reply will be the `EXEC` reply containing the redirection, if
-    -- there is one.
-    case last replies of
-        (Error errString) | B.isPrefixOf "MOVED" errString || B.isPrefixOf "EXECABORT" errString -> do
+retryBatch :: MVar ShardMap -> Connection -> [[B.ByteString]] -> [Reply] -> (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> IO [Reply]
+retryBatch shardMapVar conn requests replies withAuth =
+    if any moved replies
+        then do -- Refresh shardMap in MOVED case and do redis call
             let (Connection _ _ _ infoMap _) = conn
             keys <- mconcat <$> mapM (requestKeys infoMap) requests
             hashSlot <- hashSlotForKeys (CrossSlotException requests) keys
             nodeConn <- nodeConnForHashSlot shardMapVar conn (MissingNodeException (head requests)) hashSlot
             requestNode nodeConn requests
-        (askingRedirection -> Just (host, port)) -> do
-            shardMap <- hasLocked $ readMVar shardMapVar
-            maybeAskNode <- nodeConnWithHostAndPort shardMap conn host port
-            case maybeAskNode of
-                Just askNode -> tail <$> requestNode askNode (["ASKING"] : requests)
-                Nothing -> case retryCount of
-                    0 -> do
-                        _ <- hasLocked $ modifyMVar_ shardMapVar (const refreshShardmapAction)
-                        retryBatch shardMapVar refreshShardmapAction conn (retryCount + 1) requests replies
-                    _ -> throwIO $ MissingNodeException (head requests)
-        _ -> return replies
+        else case msum (askingRedirection <$> replies) of
+            Just (host, port) -> do
+                shardMap <- hasLocked $ readMVar shardMapVar
+                maybeAskNode <- nodeConnWithHostAndPort shardMap conn host port
+                case maybeAskNode of
+                    Just askNode -> tail <$> requestNode askNode (["ASKING"] : requests)
+                    Nothing -> do
+                        retryRes <- try $ do -- Connect with redirected host and port in ASK case
+                            (_, askNode@(NodeConnection nodeCtx _ _)) <- connectNode withAuth Nothing (Node "nodeId" Master host port)
+                            res <- tail <$> requestNode askNode (["ASKING"] : requests)
+                            CC.disconnect nodeCtx -- Disconnect after making redis call
+                            pure res
+                        case retryRes of
+                            Right r -> pure r
+                            Left (err :: SomeException) -> throwIO $ MissingNodeException [Char8.pack $ "ASK retry failed with error: " <> show err]
+            Nothing -> return replies
 
 -- Like `evaluateOnPipeline`, except we expect to be able to run all commands
 -- on a single shard. Failing to meet this expectation is an error.
-evaluateTransactionPipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> IO [Reply]
-evaluateTransactionPipeline shardMapVar refreshShardmapAction conn requests' = do
+evaluateTransactionPipeline :: MVar ShardMap -> IO ShardMap -> Connection -> [[B.ByteString]] -> (Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext) -> IO [Reply]
+evaluateTransactionPipeline shardMapVar refreshShardmapAction conn requests' withAuth = do
     let requests = reverse requests'
     let (Connection _ _ _ infoMap _) = conn
     keys <- mconcat <$> mapM (requestKeys infoMap) requests
@@ -391,7 +394,7 @@ evaluateTransactionPipeline shardMapVar refreshShardmapAction conn requests' = d
     when (any moved resps)
       (hasLocked $ modifyMVar_ shardMapVar (const refreshShardmapAction))
 
-    retryBatch shardMapVar refreshShardmapAction conn 0 requests resps
+    retryBatch shardMapVar conn requests resps withAuth
 
 
 nodeConnForHashSlot :: Exception e => MVar ShardMap -> Connection -> e -> HashSlot -> IO NodeConnection

--- a/src/Database/Redis/Cluster/HashSlot.hs
+++ b/src/Database/Redis/Cluster/HashSlot.hs
@@ -19,9 +19,10 @@ keyToSlot = HashSlot . (.&.) (numHashSlots - 1) . crc16 . findSubKey
 -- | Find the section of a key to compute the slot for.
 findSubKey :: BS.ByteString -> BS.ByteString
 findSubKey key = case Char8.break (=='{') key of
-  (whole, "") -> whole
+  (_, "") -> key -- No '{'
   (_, xs) -> case Char8.break (=='}') (Char8.tail xs) of
-    ("", _) -> key
+    ("", _) -> key -- Nothing between {}
+    (_, "") -> key -- No '}'
     (subKey, _) -> subKey
 
 crc16 :: BS.ByteString -> Word16

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -203,8 +203,8 @@ withCheckedConnect connInfo = bracket (checkedConnect connInfo) disconnect
 runRedis :: Connection -> Redis a -> IO a
 runRedis (NonClusteredConnection pool) redis =
   withResource pool $ \conn -> runRedisInternal conn redis
-runRedis (ClusteredConnection _ pool bootstrapConnInfo) redis =
-    withResource pool $ \conn -> runRedisClusteredInternal conn (refreshShardMap conn bootstrapConnInfo) redis
+runRedis (ClusteredConnection _ pool bootstrapConnInfo ) redis =
+    withResource pool $ \conn -> runRedisClusteredInternal conn (connectWithAuth bootstrapConnInfo) (refreshShardMap conn bootstrapConnInfo) redis
 
 newtype ClusterConnectError = ClusterConnectError Reply
     deriving (Eq, Show, Typeable)

--- a/src/Database/Redis/Core/Internal.hs
+++ b/src/Database/Redis/Core/Internal.hs
@@ -13,6 +13,7 @@ import Database.Redis.Protocol
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import qualified Database.Redis.ProtocolPipelining as PP
 import qualified Database.Redis.Cluster as Cluster
+import qualified Database.Redis.ConnectionContext as CC
 
 -- |Context for normal command execution, outside of transactions. Use
 --  'runRedis' to run actions of this type.
@@ -31,6 +32,7 @@ data RedisEnv
         { refreshAction :: IO Cluster.ShardMap
         , connection :: Cluster.Connection
         , clusteredLastReply :: IORef Reply
+        , withAuth :: Cluster.Host -> CC.PortID -> Maybe Int -> IO CC.ConnectionContext
         }
 
 envLastReply :: RedisEnv -> IORef Reply


### PR DESCRIPTION
Added retry in `refreshShardMapWithNodeConn` and handled MULTI MOVED in `evaluateTransactionPipeline`
Control retries in `refreshShardMapWithNodeConn` using `REFRESH_SHARD_MAP_RETRIES`
Handled `ASK` redirection

Tested moved error with this logic
```
print (show hashSlot)
    shardMap <- readMVar shardMapVar
    let shardMap' = case shardMap of
            (ShardMap shardMap'') -> do
                let a = (Shard (Node "8b3f753fa1b20be31a4d557541e0ab51adc3f262" Master "127.0.0.2" 8082) [])
                DII.insert 13447 a shardMap''
    modifyMVar_ shardMapVar (const (pure $ ShardMap shardMap'))
    v <- (\(ShardMap mp) -> DII.lookup 13447 mp) <$> (readMVar shardMapVar)
    print ("ShardValue: " <> show v)
```

Retry logic testing
```
ERROR: ClusterConnectError (Error "Couldn't refresh shardMap due to error: ClusterConnectError (Error \"Testing retry.. 0\") Prev errors: \"ClusterConnectError (Error \\\"Testing retry.. 1\\\"). ClusterConnectError (Error \\\"Testing retry.. 2\\\"). \"")
```