### PR TITLE
Move NOACK before COUNT in XREADGROUP

### DIFF
--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -892,7 +892,7 @@ xreadOpts streamsAndIds opts = sendRequest $
 
 internalXreadArgs :: [(ByteString, ByteString)] -> XReadOpts -> [ByteString]
 internalXreadArgs streamsAndIds XReadOpts{..} =
-    concat [blockArgs, countArgs, noackArgs, ["STREAMS"], streams, recordIds]
+    concat [blockArgs, noackArgs, countArgs, ["STREAMS"], streams, recordIds]
     where
         blockArgs = maybe [] (\blockMillis -> ["BLOCK", encode blockMillis]) block
         countArgs = maybe [] (\countRecords -> ["COUNT", encode countRecords]) recordCount


### PR DESCRIPTION
Issue: UnsupportedClusterCommandException being thrown when NOACK is placed after COUNT in XREADGROUP.
Fix: Moving NOACK before COUNT in XREADGROUP in internalXreadArgs.

Test:
`ghci> let cm = ["XREADGROUP","GROUP","TXN_SYNC_GROUP","consumer_a57fc824ae60471593c0955bfe485116","NOACK","COUNT","1","STREAMS","HS_STREAM{shard-44}",  ">"]`
`ghci> let cmb = (E.encodeUtf8 . pack) <$> cm`
`ghci> parseMovable cmb`
`Just ["HS_STREAM{shard-44}"]`
`ghci> `