### PR TITLE
Exported Queued constructor

### DIFF
--- a/src/Database/Redis/Transactions.hs
+++ b/src/Database/Redis/Transactions.hs
@@ -4,7 +4,7 @@
 
 module Database.Redis.Transactions (
     watch, unwatch, multiExec,
-    Queued(), TxResult(..), RedisTx(),
+    Queued(..), TxResult(..), RedisTx(),
 ) where
 
 #if __GLASGOW_HASKELL__ < 710


### PR DESCRIPTION
Exported Queued constructor, which is needed for applying decompression in multi exec based calls