### PR TITLE
Added retry + delay for TRYAGAIN error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog for Hedis
 
+## 0.15.6
+* PR#62. Fixed retry handling for TRYAGAIN error. (Added delay before retry and handling of MOVED / ASK error after retry)
+
 ## 0.15.5
 * PR#49. Changed connectAuth type to sum type to support dynamic auths
 * PR#49. Added requestTimeout in connectInfo for timeout of redis command

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -98,8 +98,6 @@ data ConnectInfo = ConnInfo
     -- TODO add for non cluster redis also
     , tryAgainDelay         :: Maybe Double
     -- ^ retry delay for a redis command request when TRYAGAIN error is received during cluster slot migration
-    -- default value is 100 ms
-    -- 
     } deriving Show
 
 data ConnectAuth = Static B.ByteString | Dynamic ShowableIORefByteString


### PR DESCRIPTION
When a multi-key operation targets keys where some are still on the source node and others have been migrated to the destination node, a TRYAGAIN error is returned to prompt the client to retry after the migration is complete

previously we only retried the request once when we received TRYAGAIN error, but we have come across cases where we received ASK error after this retry.

New changed include handling of MOVED and ASK error even after retry.
Also added configurable delay before retry