### PR TITLE
randomized the picking of nodes for commands with "step" as 0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # Changelog for Hedis
 
+## 0.15.6
+* PR#63. Randomized node selection in cluster mode for commands with "step" field description as 0
+
 ## 0.15.5
 * PR#49. Changed connectAuth type to sum type to support dynamic auths
 * PR#49. Added requestTimeout in connectInfo for timeout of redis command

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -400,7 +400,7 @@ hashSlotForKeys :: Exception e => e -> [B.ByteString] -> IO HashSlot
 hashSlotForKeys exception keys =
     case nubOrd (keyToSlot <$> keys) of
         -- If none of the commands contain a key we can send them to any
-        -- node. Let's pick the first one.
+        -- node. Let's pick a random one.
         [] -> HashSlot <$> randomRIO (0, numHashSlots - 1)
         [hashSlot] -> return hashSlot
         _ -> throwIO $ exception

--- a/src/Database/Redis/Cluster/HashSlot.hs
+++ b/src/Database/Redis/Cluster/HashSlot.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Database.Redis.Cluster.HashSlot(HashSlot, keyToSlot) where
+module Database.Redis.Cluster.HashSlot(HashSlot(..), keyToSlot, numHashSlots) where
 
 import Data.Bits((.&.), xor, shiftL)
 import qualified Data.ByteString.Char8 as Char8


### PR DESCRIPTION
Before commands with "step" as 0 such as PUBLISH were sent to single node by having the hashslot selection hardcoded as 0.
randomized this hashslot selection