### PR TITLE
Added support for subcommands | Fixed XINFO and XGROUP | Fixed Test cases | Removed usage of SLOWLOG and DEBUG OBJECT from client

### DIFF
--- a/src/Database/Redis/Cluster/Command.hs
+++ b/src/Database/Redis/Cluster/Command.hs
@@ -7,6 +7,7 @@ import qualified Data.ByteString.Char8 as Char8
 import qualified Data.HashMap.Strict as HM
 import Database.Redis.Types(RedisResult(decode))
 import Database.Redis.Protocol(Reply(..))
+import Control.Applicative ((<|>))
 
 data Flag
     = Write
@@ -30,7 +31,7 @@ data AritySpec = Required Integer | MinimumRequired Integer deriving (Show)
 
 data LastKeyPositionSpec = LastKeyPosition Integer | UnlimitedKeys Integer deriving (Show)
 
-newtype InfoMap = InfoMap (HM.HashMap String CommandInfo)
+newtype InfoMap = InfoMap (HM.HashMap String CommandInfo) deriving (Show)
 
 -- Represents the result of the COMMAND command, which returns information
 -- about the position of keys in a request
@@ -41,6 +42,7 @@ data CommandInfo = CommandInfo
     , firstKeyPosition :: Integer
     , lastKeyPosition :: LastKeyPositionSpec
     , stepCount :: Integer
+    , subcommandsInfo :: Maybe InfoMap
     } deriving (Show)
 
 instance RedisResult CommandInfo where
@@ -50,17 +52,64 @@ instance RedisResult CommandInfo where
         , MultiBulk (Just replyFlags)
         , Integer firstKeyPos
         , Integer lastKeyPos
-        , Integer replyStepCount])) = do
-            parsedFlags <- mapM parseFlag replyFlags
-            lastKey <- parseLastKeyPos
-            return $ CommandInfo
-                { name = commandName
-                , arity = parseArity aritySpec
-                , flags = parsedFlags
-                , firstKeyPosition = firstKeyPos
-                , lastKeyPosition = lastKey
-                , stepCount = replyStepCount
-                } where
+        , Integer replyStepCount])) = decodeCommandInfo (MultiBulk (Just
+                                        [ Bulk (Just commandName)
+                                        , Integer aritySpec
+                                        , MultiBulk (Just replyFlags)
+                                        , Integer firstKeyPos
+                                        , Integer lastKeyPos
+                                        , Integer replyStepCount
+                                        , MultiBulk Nothing])) -- added empty subcommand info for backward compatibility
+    -- since redis 6.0
+    decode (MultiBulk (Just
+        [ name@(Bulk (Just _))
+        , arity@(Integer _)
+        , flags@(MultiBulk (Just _))
+        , firstPos@(Integer _)
+        , lastPos@(Integer _)
+        , step@(Integer _)
+        , MultiBulk _  -- ACL categories
+        ])) =
+        decodeCommandInfo (MultiBulk (Just [name, arity, flags, firstPos, lastPos, step, MultiBulk Nothing]))
+    -- since redis 7.0
+    decode (MultiBulk (Just
+        [ name@(Bulk (Just _))
+        , arity@(Integer _)
+        , flags@(MultiBulk (Just _))
+        , firstPos@(Integer _)
+        , lastPos@(Integer _)
+        , step@(Integer _)
+        , MultiBulk _  -- ACL categories
+        , MultiBulk _  -- Tips
+        , MultiBulk _  -- Key specifications
+        , MultiBulk subCommandInfo  -- Sub commands
+        ])) =
+        decodeCommandInfo (MultiBulk (Just [name, arity, flags, firstPos, lastPos, step, MultiBulk subCommandInfo]))
+
+    decode e = Left e
+
+decodeCommandInfo :: Reply -> Either Reply CommandInfo
+decodeCommandInfo (MultiBulk (Just
+        [ Bulk (Just commandName)
+        , Integer aritySpec
+        , MultiBulk (Just replyFlags)
+        , Integer firstKeyPos
+        , Integer lastKeyPos
+        , Integer replyStepCount
+        , MultiBulk subcommands
+        ])) = do
+        parsedFlags <- mapM parseFlag replyFlags
+        lastKey <- parseLastKeyPos
+        subcommandsInfoMap <- parseSubcommandsInfo
+        return $ CommandInfo
+            { name = commandName
+            , arity = parseArity aritySpec
+            , flags = parsedFlags
+            , firstKeyPosition = firstKeyPos
+            , lastKeyPosition = lastKey
+            , stepCount = replyStepCount
+            , subcommandsInfo = subcommandsInfoMap
+            } where
         parseArity int = case int of
             i | i >= 0 -> Required i
             i -> MinimumRequired $ abs i
@@ -86,33 +135,14 @@ instance RedisResult CommandInfo where
         parseLastKeyPos = return $ case lastKeyPos of
             i | i < 0 -> UnlimitedKeys (-i - 1)
             i -> LastKeyPosition i
-    -- since redis 6.0
-    decode (MultiBulk (Just
-        [ name@(Bulk (Just _))
-        , arity@(Integer _)
-        , flags@(MultiBulk (Just _))
-        , firstPos@(Integer _)
-        , lastPos@(Integer _)
-        , step@(Integer _)
-        , MultiBulk _  -- ACL categories
-        ])) =
-        decode (MultiBulk (Just [name, arity, flags, firstPos, lastPos, step]))
-    -- since redis 7.0
-    decode (MultiBulk (Just
-        [ name@(Bulk (Just _))
-        , arity@(Integer _)
-        , flags@(MultiBulk (Just _))
-        , firstPos@(Integer _)
-        , lastPos@(Integer _)
-        , step@(Integer _)
-        , MultiBulk _  -- ACL categories
-        , MultiBulk _  -- Tips
-        , MultiBulk _  -- Key specifications
-        , MultiBulk _  -- Sub commands
-        ])) =
-        decode (MultiBulk (Just [name, arity, flags, firstPos, lastPos, step]))
-
-    decode e = Left e
+        parseSubcommandsInfo :: Either Reply (Maybe InfoMap)
+        parseSubcommandsInfo = do
+            subCommandInfo <- decode (MultiBulk subcommands)
+            case subCommandInfo of
+                Nothing     -> return Nothing
+                Just []     -> return Nothing
+                Just cmds   -> return $ Just $ newInfoMap cmds
+decodeCommandInfo reply = Left reply -- unknown and unexpected 
 
 newInfoMap :: [CommandInfo] -> InfoMap
 newInfoMap = InfoMap . HM.fromList . map (\c -> (Char8.unpack $ name c, c))
@@ -125,9 +155,16 @@ keysForRequest _ ["DEBUG", "OBJECT", key] =
 keysForRequest _ ["QUIT"] =
     -- The `QUIT` command is not listed in the `COMMAND` output.
     Just []
-keysForRequest (InfoMap infoMap) request@(command:_) = do
+keysForRequest (InfoMap infoMap) request@(command:remainingArgs) = do
     info <- HM.lookup (map toLower $ Char8.unpack command) infoMap
-    keysForRequest' info request
+    finalCommandInfo <- case subcommandsInfo info of
+                            Nothing                             -> Just info
+                            Just (InfoMap subcommandsInfoMap)   -> 
+                                    case remainingArgs of
+                                        (subcommand:_) -> HM.lookup (map toLower (Char8.unpack command ++ "|" ++ Char8.unpack subcommand)) subcommandsInfoMap 
+                                                                <|> Just info -- as a fallback
+                                        _ -> Just info
+    keysForRequest' finalCommandInfo request
 keysForRequest _ [] = Nothing
 
 keysForRequest' :: CommandInfo -> [BS.ByteString] -> Maybe [BS.ByteString]

--- a/src/Database/Redis/Commands.hs
+++ b/src/Database/Redis/Commands.hs
@@ -120,7 +120,6 @@ configResetstat, -- |Reset the stats returned by INFO (<http://redis.io/commands
 configRewrite, -- |Rewrite the configuration file with the in memory configuration (<http://redis.io/commands/config-rewrite>). Since Redis 2.8.0
 configSet, -- |Set a configuration parameter to the given value (<http://redis.io/commands/config-set>). Since Redis 2.0.0
 dbsize, -- |Return the number of keys in the selected database (<http://redis.io/commands/dbsize>). Since Redis 1.0.0
-debugObject, -- |Get debugging information about a key (<http://redis.io/commands/debug-object>). Since Redis 1.0.0
 flushall, -- |Remove all keys from all databases (<http://redis.io/commands/flushall>). Since Redis 1.0.0
 flushdb, -- |Remove all keys from the current database (<http://redis.io/commands/flushdb>). Since Redis 1.0.0
 info, -- |Get information and statistics about the server (<http://redis.io/commands/info>). The Redis command @INFO@ is split up into 'info', 'infoSection'. Since Redis 1.0.0
@@ -128,10 +127,11 @@ infoSection, -- |Get information and statistics about the server (<http://redis.
 lastsave, -- |Get the UNIX time stamp of the last successful save to disk (<http://redis.io/commands/lastsave>). Since Redis 1.0.0
 save, -- |Synchronously save the dataset to disk (<http://redis.io/commands/save>). Since Redis 1.0.0
 slaveof, -- |Make the server a slave of another instance, or promote it as master (<http://redis.io/commands/slaveof>). Since Redis 1.0.0
-Slowlog(..),
-slowlogGet, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
-slowlogLen, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
-slowlogReset, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
+-- TODO: Need to Fix for the commands which are cluster implementation independent
+-- Slowlog(..),
+-- slowlogGet, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
+-- slowlogLen, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
+-- slowlogReset, -- |Manages the Redis slow queries log (<http://redis.io/commands/slowlog>). The Redis command @SLOWLOG@ is split up into 'slowlogGet', 'slowlogLen', 'slowlogReset'. Since Redis 2.2.12
 time, -- |Return the current server time (<http://redis.io/commands/time>). Since Redis 2.6.0
 
 -- ** Sets
@@ -413,12 +413,6 @@ rpushx
     -> ByteString -- ^ value
     -> m (f Integer)
 rpushx key value = sendRequest (["RPUSHX"] ++ [encode key] ++ [encode value] )
-
-debugObject
-    :: (RedisCtx m f)
-    => ByteString -- ^ key
-    -> m (f ByteString)
-debugObject key = sendRequest (["DEBUG","OBJECT"] ++ [encode key] )
 
 bgsave
     :: (RedisCtx m f)

--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -1260,6 +1260,7 @@ data XInfoConsumersResponse = XInfoConsumersResponse
     { xinfoConsumerName :: ByteString
     , xinfoConsumerNumPendingMessages :: Integer
     , xinfoConsumerIdleTime :: Integer
+    , xinfoConsumerInactiveTime :: Maybe Integer
     } deriving (Show, Eq)
 
 instance RedisResult XInfoConsumersResponse where
@@ -1269,7 +1270,25 @@ instance RedisResult XInfoConsumersResponse where
         Bulk (Just "pending"),
         Integer xinfoConsumerNumPendingMessages,
         Bulk (Just "idle"),
-        Integer xinfoConsumerIdleTime])) = Right XInfoConsumersResponse{..}
+        Integer xinfoConsumerIdleTime])) = Right XInfoConsumersResponse
+            { 
+              xinfoConsumerInactiveTime = Nothing,
+              ..
+            } -- TODO: Remove post migration to > 7
+    decode (MultiBulk (Just [
+        Bulk (Just "name"),
+        Bulk (Just xinfoConsumerName),
+        Bulk (Just "pending"),
+        Integer xinfoConsumerNumPendingMessages,
+        Bulk (Just "idle"),
+        Integer xinfoConsumerIdleTime,
+        Bulk (Just "inactive"),
+        Integer xinfoConsumerInactiveTime                                  -- TODO: add inactive time
+        ])) = Right XInfoConsumersResponse
+            {
+                xinfoConsumerInactiveTime = Just xinfoConsumerInactiveTime,
+                ..
+            }
     decode a = Left a
 
 xinfoConsumers
@@ -1284,6 +1303,8 @@ data XInfoGroupsResponse = XInfoGroupsResponse
     , xinfoGroupsNumConsumers :: Integer
     , xinfoGroupsNumPendingMessages :: Integer
     , xinfoGroupsLastDeliveredMessageId :: ByteString
+    , xinfoGroupsNumEntriesRead :: Maybe Integer
+    , xinfoGroupsLag :: Maybe Integer
     } deriving (Show, Eq)
 
 instance RedisResult XInfoGroupsResponse where
@@ -1291,7 +1312,22 @@ instance RedisResult XInfoGroupsResponse where
         Bulk (Just "name"),Bulk (Just xinfoGroupsGroupName),
         Bulk (Just "consumers"),Integer xinfoGroupsNumConsumers,
         Bulk (Just "pending"),Integer xinfoGroupsNumPendingMessages,
-        Bulk (Just "last-delivered-id"),Bulk (Just xinfoGroupsLastDeliveredMessageId)])) = Right XInfoGroupsResponse{..}
+        Bulk (Just "last-delivered-id"),Bulk (Just xinfoGroupsLastDeliveredMessageId)])) = Right XInfoGroupsResponse{
+            xinfoGroupsNumEntriesRead = Nothing,
+            xinfoGroupsLag = Nothing,
+            ..
+        } -- TODO: Remove post migration to > 7
+    decode (MultiBulk (Just [
+        Bulk (Just "name"),Bulk (Just xinfoGroupsGroupName),
+        Bulk (Just "consumers"),Integer xinfoGroupsNumConsumers,
+        Bulk (Just "pending"),Integer xinfoGroupsNumPendingMessages,
+        Bulk (Just "last-delivered-id"),Bulk (Just xinfoGroupsLastDeliveredMessageId),
+        Bulk (Just "entries-read"),Integer xinfoGroupsNumEntriesRead,
+        Bulk (Just "lag"),Integer xinfoGroupsLag])) = Right XInfoGroupsResponse{
+            xinfoGroupsNumEntriesRead = Just xinfoGroupsNumEntriesRead,
+            xinfoGroupsLag = Just xinfoGroupsLag,
+            ..
+        }
     decode a = Left a
 
 xinfoGroups
@@ -1309,6 +1345,9 @@ data XInfoStreamResponse
     , xinfoStreamLastEntryId :: ByteString
     , xinfoStreamFirstEntry :: StreamsRecord
     , xinfoStreamLastEntry :: StreamsRecord
+    , xinfoMaxDeletedEntryId :: Maybe ByteString
+    , xinfoEntriesAdded :: Maybe Integer
+    , xinfoRecordedFirstEntryId :: Maybe ByteString
     } 
     | XInfoStreamEmptyResponse
     { xinfoStreamLength :: Integer
@@ -1316,11 +1355,14 @@ data XInfoStreamResponse
     , xinfoStreamRadixTreeNodes :: Integer
     , xinfoStreamNumGroups :: Integer
     , xinfoStreamLastEntryId :: ByteString
+    , xinfoMaxDeletedEntryId :: Maybe ByteString
+    , xinfoEntriesAdded :: Maybe Integer
+    , xinfoRecordedFirstEntryId :: Maybe ByteString
     }
     deriving (Show, Eq)
 
 instance RedisResult XInfoStreamResponse where
-    decode = decodeRedis5 <> decodeRedis6
+    decode = decodeRedis5 <> decodeRedis6 <> decodeRedis7
         where
             decodeRedis5 (MultiBulk (Just [
                  Bulk (Just "length"),Integer xinfoStreamLength,
@@ -1330,7 +1372,11 @@ instance RedisResult XInfoStreamResponse where
                  Bulk (Just "last-generated-id"),Bulk (Just xinfoStreamLastEntryId),
                  Bulk (Just "first-entry"), Bulk Nothing ,
                  Bulk (Just "last-entry"), Bulk Nothing ])) = do
-                     return XInfoStreamEmptyResponse{..}
+                     return XInfoStreamEmptyResponse {
+                          xinfoMaxDeletedEntryId = Nothing 
+                        , xinfoEntriesAdded = Nothing
+                        , xinfoRecordedFirstEntryId = Nothing
+                        ,..}
             decodeRedis5 (MultiBulk (Just [
                 Bulk (Just "length"),Integer xinfoStreamLength,
                 Bulk (Just "radix-tree-keys"),Integer xinfoStreamRadixTreeKeys,
@@ -1341,7 +1387,11 @@ instance RedisResult XInfoStreamResponse where
                 Bulk (Just "last-entry"), rawLastEntry ])) = do
                     xinfoStreamFirstEntry <- decode rawFirstEntry
                     xinfoStreamLastEntry <- decode rawLastEntry
-                    return XInfoStreamResponse{..}
+                    return XInfoStreamResponse {
+                          xinfoMaxDeletedEntryId = Nothing 
+                        , xinfoEntriesAdded = Nothing
+                        , xinfoRecordedFirstEntryId = Nothing
+                        , ..}
             decodeRedis5 a = Left a
 
             decodeRedis6 (MultiBulk (Just [
@@ -1352,7 +1402,11 @@ instance RedisResult XInfoStreamResponse where
                 Bulk (Just "groups"),Integer xinfoStreamNumGroups,
                 Bulk (Just "first-entry"), Bulk Nothing ,
                 Bulk (Just "last-entry"), Bulk Nothing ])) = do
-                    return XInfoStreamEmptyResponse{..}
+                    return XInfoStreamEmptyResponse {
+                          xinfoMaxDeletedEntryId = Nothing 
+                        , xinfoEntriesAdded = Nothing
+                        , xinfoRecordedFirstEntryId = Nothing
+                        ,..}
             decodeRedis6 (MultiBulk (Just [
                 Bulk (Just "length"),Integer xinfoStreamLength,
                 Bulk (Just "radix-tree-keys"),Integer xinfoStreamRadixTreeKeys,
@@ -1363,8 +1417,48 @@ instance RedisResult XInfoStreamResponse where
                 Bulk (Just "last-entry"), rawLastEntry ])) = do
                     xinfoStreamFirstEntry <- decode rawFirstEntry
                     xinfoStreamLastEntry <- decode rawLastEntry
-                    return XInfoStreamResponse{..}
+                    return XInfoStreamResponse {
+                          xinfoMaxDeletedEntryId = Nothing 
+                        , xinfoEntriesAdded = Nothing
+                        , xinfoRecordedFirstEntryId = Nothing
+                        ,..}
             decodeRedis6 a = Left a
+
+            decodeRedis7 (MultiBulk (Just [
+                Bulk (Just "length"),Integer xinfoStreamLength,
+                Bulk (Just "radix-tree-keys"),Integer xinfoStreamRadixTreeKeys,
+                Bulk (Just "radix-tree-nodes"),Integer xinfoStreamRadixTreeNodes,
+                Bulk (Just "last-generated-id"),Bulk (Just xinfoStreamLastEntryId),
+                Bulk (Just "max-deleted-entry-id"), Bulk (Just xinfoMaxDeletedEntryId),
+                Bulk (Just "entries-added"),Integer xinfoEntriesAdded,
+                Bulk (Just "recorded-first-entry-id"), Bulk (Just xinfoRecordedFirstEntryId),
+                Bulk (Just "groups"),Integer xinfoStreamNumGroups,
+                Bulk (Just "first-entry"), Bulk Nothing ,
+                Bulk (Just "last-entry"), Bulk Nothing ])) = do
+                    return XInfoStreamEmptyResponse {
+                          xinfoMaxDeletedEntryId = Just xinfoMaxDeletedEntryId 
+                        , xinfoEntriesAdded = Just xinfoEntriesAdded
+                        , xinfoRecordedFirstEntryId = Just xinfoRecordedFirstEntryId
+                        ,..}
+            decodeRedis7 (MultiBulk (Just [
+                Bulk (Just "length"),Integer xinfoStreamLength,
+                Bulk (Just "radix-tree-keys"),Integer xinfoStreamRadixTreeKeys,
+                Bulk (Just "radix-tree-nodes"),Integer xinfoStreamRadixTreeNodes,
+                Bulk (Just "last-generated-id"),Bulk (Just xinfoStreamLastEntryId),
+                Bulk (Just "max-deleted-entry-id"), Bulk (Just xinfoMaxDeletedEntryId),
+                Bulk (Just "entries-added"),Integer xinfoEntriesAdded,
+                Bulk (Just "recorded-first-entry-id"), Bulk (Just xinfoRecordedFirstEntryId) ,
+                Bulk (Just "groups"),Integer xinfoStreamNumGroups,
+                Bulk (Just "first-entry"), rawFirstEntry ,
+                Bulk (Just "last-entry"), rawLastEntry ])) = do
+                    xinfoStreamFirstEntry <- decode rawFirstEntry
+                    xinfoStreamLastEntry <- decode rawLastEntry
+                    return XInfoStreamResponse {
+                          xinfoMaxDeletedEntryId = Just xinfoMaxDeletedEntryId 
+                        , xinfoEntriesAdded = Just xinfoEntriesAdded
+                        , xinfoRecordedFirstEntryId = Just xinfoRecordedFirstEntryId
+                        ,..}
+            decodeRedis7 a = Left a
 
 xinfoStream
     :: (RedisCtx m f)

--- a/test/ClusterMain.hs
+++ b/test/ClusterMain.hs
@@ -30,7 +30,7 @@ tests conn = map ($conn) $ concat
 
 testsServer :: [Test]
 testsServer =
-    [testBgrewriteaof, testFlushall, testSlowlog, testDebugObject]
+    [testBgrewriteaof, testFlushall]
 
 testsConnection :: [Test]
 testsConnection = [ testConnectAuthUnexpected, testEcho, testPing

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,7 +25,7 @@ tests conn = map ($conn) $ concat
 testsServer :: [Test]
 testsServer =
     [testServer, testBgrewriteaof, testFlushall, testInfo, testConfig
-    ,testSlowlog, testDebugObject]
+    ]
 
 testsConnection :: [Test]
 testsConnection = [ testConnectAuth, testConnectAuthUnexpected, testConnectDb

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -568,12 +568,14 @@ testBgrewriteaof = testCase "bgrewriteaof/bgsave/save" $ do
     save >>=? Ok
     bgsave >>= \case
       Right (Status _) -> return ()
-      _ -> error "error"
+      Right err -> error $ show err
+      Left err -> error $ show err
     -- Redis needs time to finish the bgsave
     liftIO $ threadDelay (10^(5 :: Int))
     bgrewriteaof >>= \case
       Right (Status _) -> return ()
-      _ -> error "error"
+      Right err -> error $ show err
+      Left err -> error $ show err
     return ()
 
 testConfig :: Test
@@ -599,19 +601,11 @@ testInfo = testCase "info/lastsave/dbsize" $ do
     dbsize          >>=? 0
     configResetstat >>=? Ok
 
-testSlowlog :: Test
-testSlowlog = testCase "slowlog" $ do
-    slowlogReset >>=? Ok
-    slowlogGet 5 >>=? []
-    slowlogLen   >>=? 0
-
-testDebugObject :: Test
-testDebugObject = testCase "debugObject/debugSegfault" $ do
-    set "key" "value" >>=? Ok
-    debugObject "key" >>= \case
-      Left _ -> error "error"
-      _ -> return ()
-    return ()
+-- testSlowlog :: Test
+-- testSlowlog = testCase "slowlog" $ do
+--     slowlogReset >>=? Ok
+--     slowlogGet 5 >>=? []
+--     slowlogLen   >>=? 0
 
 testScans :: Test
 testScans = testCase "scans" $ do
@@ -808,7 +802,9 @@ testXInfo = testCase "xinfo" $ do
             xinfoGroupsGroupName = "somegroup",
             xinfoGroupsNumConsumers = 1,
             xinfoGroupsNumPendingMessages = 2,
-            xinfoGroupsLastDeliveredMessageId = "122-0"
+            xinfoGroupsLastDeliveredMessageId = "122-0",
+            xinfoGroupsNumEntriesRead = Just 2,
+            xinfoGroupsLag = Just 0
         }]
     xinfoStream "somestream" >>=? XInfoStreamResponse
         { xinfoStreamLength = 2
@@ -824,6 +820,9 @@ testXInfo = testCase "xinfo" $ do
             { recordId = "122-0"
             , keyValues = [("key2", "value2")]
             }
+        , xinfoMaxDeletedEntryId = Just "0-0"
+        , xinfoEntriesAdded = Just 2
+        , xinfoRecordedFirstEntryId = Just "121-0"
         }
 
 testXDel ::Test


### PR DESCRIPTION
### Problem
Currently [Subcommands](https://valkey.io/commands/command/) are not supported and this results in not correctly extracting the keys and causing the moved errors in the Commands which have subcommands for example: [XINFO](https://valkey.io/commands/xinfo/), [XGROUP](https://valkey.io/commands/xgroup/). 
### Solution
Added the SubCommandsInfo to the CommandInfo and during the the key extraction, a check is made if the command has subcommands and the command info is fetched from the Subcommandinfo which used for key extraction
### Additional Changes Made with Reason
Removed [DEBUG OBJECT](https://valkey.io/commands/debug/) because it used for developing and testing Valkey.
Removed [SLOWLOG](https://valkey.io/commands/slowlog/), Ideally SLOWLOG should be run with administrative client like valkey-cli and moreover SLOWLOG requires to be run on a node, it doesn't have a key. [Additional support needed to support such kind of commands](https://github.com/juspay/hedis/issues/65).