### PR TITLE
Support for MINID, approx trimming, and LIMITs

### DIFF
--- a/src/Database/Redis/ManualCommands.hs
+++ b/src/Database/Redis/ManualCommands.hs
@@ -935,7 +935,7 @@ zrangebylexLimit key min max offset count  =
     sendRequest ["ZRANGEBYLEX", encode key, encode min, encode max,
                  "LIMIT", encode offset, encode count]
 
-data TrimOpts = NoArgs | Maxlen Integer | ApproxMaxlen Integer
+data TrimOpts = NoArgs | Maxlen Integer | ApproxMaxlen Integer | ApproxMaxlenWithLimit Integer Integer | Minid ByteString | ApproxMinid ByteString | ApproxMinidWithLimit ByteString Integer
 
 xaddOpts
     :: (RedisCtx m f)
@@ -952,6 +952,10 @@ xaddOpts key entryId fieldValues opts = sendRequest $
             NoArgs -> []
             Maxlen max -> ["MAXLEN", encode max]
             ApproxMaxlen max -> ["MAXLEN", "~", encode max]
+            ApproxMaxlenWithLimit max lim -> ["MAXLEN", "~", encode max, "LIMIT", encode lim]
+            Minid mid -> ["MINID", mid]
+            ApproxMinid mid -> ["MINID", "~", mid]
+            ApproxMinidWithLimit mid lim -> ["MINID", "~", mid, "LIMIT", encode lim]
 
 xadd
     :: (RedisCtx m f)
@@ -1484,6 +1488,10 @@ xtrim stream opts = sendRequest $ ["XTRIM", stream] ++ optArgs
             NoArgs -> []
             Maxlen max -> ["MAXLEN", encode max]
             ApproxMaxlen max -> ["MAXLEN", "~", encode max]
+            ApproxMaxlenWithLimit max lim -> ["MAXLEN", "~", encode max, "LIMIT", encode lim]
+            Minid mid -> ["MINID", mid]
+            ApproxMinid mid -> ["MINID", "~", mid]
+            ApproxMinidWithLimit mid lim -> ["MINID", "~", mid, "LIMIT", encode lim]
 
 inf :: RealFloat a => a
 inf = 1 / 0

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -15,7 +15,7 @@ tests conn = map ($conn) $ concat
     [ testsGeoSets,testsMisc, testsKeys, testsStrings, [testHashes], testsLists, testsSets, [testHyperLogLog]
     , testsZSets, [testPubSub], [testTransaction], [testScripting]
     , testsConnection, testsServer, [testScans, testSScan, testHScan, testZScan], [testZrangelex]
-    , [testXAddRead, testXReadGroup, testXRange, testXpending, testXPendingWithIdle, testXClaim, testXInfo, testXDel, testXTrim]
+    , [testXAddRead, testXReadGroup, testXRange, testXpending, testXPendingWithIdle, testXClaim, testXInfo, testXDel, testXTrim, testXTrimMinid, testXAddMinid, testXTrimWithLimit, testXAddWithLimit]
     , testPubSubThreaded
     , [testFunctionLoad, testFCall, testFunctionList, testFunctionDelete]
       -- should always be run last as connection gets closed after it

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -841,6 +841,87 @@ testXTrim = testCase "xtrim" $ do
     xadd "somestream" "125" [("key5", "value5")]
     xtrim "somestream" (Maxlen 2) >>=? 3
 
+testXTrimMinid :: Test
+testXTrimMinid = testCase "xtrim minid" $ do
+    xadd "trimminid" "100" [("k", "v1")]
+    xadd "trimminid" "200" [("k", "v2")]
+    xadd "trimminid" "300" [("k", "v3")]
+    xadd "trimminid" "400" [("k", "v4")]
+    xtrim "trimminid" (Minid "300") >>=? 2
+    xlen "trimminid" >>=? 2
+
+    xadd "trimapproxminid" "100" [("k", "v1")]
+    xadd "trimapproxminid" "200" [("k", "v2")]
+    xadd "trimapproxminid" "300" [("k", "v3")]
+    xadd "trimapproxminid" "400" [("k", "v4")]
+    xtrim "trimapproxminid" (ApproxMinid "300") >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right trimmed -> assert (trimmed >= 0 && trimmed <= 2)
+    xlen "trimapproxminid" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l -> assert (l >= 2 && l <= 4)
+
+testXAddMinid :: Test
+testXAddMinid = testCase "xadd minid trim" $ do
+    xadd "addminid" "100" [("k", "v1")]
+    xadd "addminid" "200" [("k", "v2")]
+    xadd "addminid" "300" [("k", "v3")]
+    xaddOpts "addminid" "*" [("k", "v4")] (Minid "300")
+    xlen "addminid" >>=? 2
+
+    xadd "addapproxminid" "100" [("k", "v1")]
+    xadd "addapproxminid" "200" [("k", "v2")]
+    xadd "addapproxminid" "300" [("k", "v3")]
+    xaddOpts "addapproxminid" "*" [("k", "v4")] (ApproxMinid "300")
+    xlen "addapproxminid" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l -> assert (l >= 2 && l <= 4)
+
+testXTrimWithLimit :: Test
+testXTrimWithLimit = testCase "xtrim with limit" $ do
+    xadd "trimmaxlenlimit" "100" [("k", "v1")]
+    xadd "trimmaxlenlimit" "200" [("k", "v2")]
+    xadd "trimmaxlenlimit" "300" [("k", "v3")]
+    xadd "trimmaxlenlimit" "400" [("k", "v4")]
+    xadd "trimmaxlenlimit" "500" [("k", "v5")]
+    xtrim "trimmaxlenlimit" (ApproxMaxlenWithLimit 2 1) >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right trimmed -> assert (trimmed >= 0 && trimmed <= 1)
+    xlen "trimmaxlenlimit" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l -> assert (l <= 5 && l >= 4)
+
+    xadd "trimminidlimit" "100" [("k", "v1")]
+    xadd "trimminidlimit" "200" [("k", "v2")]
+    xadd "trimminidlimit" "300" [("k", "v3")]
+    xadd "trimminidlimit" "400" [("k", "v4")]
+    xtrim "trimminidlimit" (ApproxMinidWithLimit "300" 1) >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right trimmed2 -> assert (trimmed2 >= 0 && trimmed2 <= 1)
+    xlen "trimminidlimit" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l2 -> assert (l2 <= 4 && l2 >= 3)
+
+testXAddWithLimit :: Test
+testXAddWithLimit = testCase "xadd with limit trim" $ do
+    xadd "addmaxlenlimit" "100" [("k", "v1")]
+    xadd "addmaxlenlimit" "200" [("k", "v2")]
+    xadd "addmaxlenlimit" "300" [("k", "v3")]
+    xadd "addmaxlenlimit" "400" [("k", "v4")]
+    xaddOpts "addmaxlenlimit" "*" [("k", "v5")] (ApproxMaxlenWithLimit 2 1)
+    xlen "addmaxlenlimit" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l -> assert (l <= 5 && l >= 4)
+
+    xadd "addminidlimit" "100" [("k", "v1")]
+    xadd "addminidlimit" "200" [("k", "v2")]
+    xadd "addminidlimit" "300" [("k", "v3")]
+    xadd "addminidlimit" "400" [("k", "v4")]
+    xaddOpts "addminidlimit" "*" [("k", "v5")] (ApproxMinidWithLimit "300" 1)
+    xlen "addminidlimit" >>= \case
+      Left reply -> liftIO $ HUnit.assertFailure $ "Redis error: " ++ show reply
+      Right l2 -> assert (l2 <= 5 && l2 >= 4)
+
 testFunctionLoad :: Test
 testFunctionLoad = testCase "functionLoad" $ do
     let fCallLib = $(embedFile "test/fcall_test.lua")


### PR DESCRIPTION
Extended TrimOpts to support MINID-based trimming along with approximate trimming using LIMIT.

Redis introduced support for MINID trimming with LIMIT in version 6.2 for both XADD and XTRIM commands.
https://redis.io/docs/latest/commands/xadd/
https://redis.io/docs/latest/commands/xtrim/