### PR TITLE
Fix stale ShardMap overwrite after cluster failover via epoch guard

### DIFF
--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -118,8 +118,13 @@ type SlaveNode = Node
 -- until it changes).
 data Shard = Shard MasterNode [SlaveNode] deriving (Show, Eq, Ord)
 
--- A map from hashslot to shards
-newtype ShardMap = ShardMap (IntMap.IntMap Shard) deriving (Show)
+-- A map from hashslot to shards, tagged with the cluster's current epoch
+-- so that stale CLUSTER SLOTS responses (from gossip-lagged nodes) are never
+-- allowed to overwrite a newer ShardMap that another thread already wrote.
+data ShardMap = ShardMap
+    { shardMapSlots :: IntMap.IntMap Shard
+    , shardMapEpoch :: !Int   -- cluster_current_epoch at the time of the last CLUSTER SLOTS fetch
+    } deriving (Show)
 
 type NodeConnectionMap = HM.HashMap NodeID NodeConnection
 
@@ -149,9 +154,7 @@ createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMa
         nodeConns <- nodeConnections
         shardNodeVar <- newMVar (shardMap, nodeConns)
         nodeRequestTimeout <- round . (\x -> (x :: Time.NominalDiffTime) * 1000000) . realToFrac . fromMaybe (5 :: Double) . (requestTimeoutSeconds <|> ). (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
-        let clusterConfig = ClusterConfig {
-                    requestTimeout = nodeRequestTimeout
-                }
+        let clusterConfig = ClusterConfig { requestTimeout = nodeRequestTimeout }
         return $ Connection shardNodeVar (CMD.newInfoMap commandInfos) clusterConfig where
     nodeConnections :: IO (HM.HashMap NodeID NodeConnection)
     nodeConnections = do
@@ -160,7 +163,7 @@ createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMa
 
 createNodePool :: (Host -> CC.PortID -> IO CC.ConnectionContext) -> Int -> Time.NominalDiffTime -> Node -> IO (NodeID, NodeConnection)
 createNodePool withAuth maxResources idleTime (Node nodeid _ host port) = do
-    connectionPool <- createPool (do 
+    connectionPool <- createPool (do
                                     connectionContext <- withAuth host (CC.PortNumber $ toEnum port)
                                     ref <- IOR.newIORef Nothing
                                     return (connectionContext,ref)) (CC.disconnect . fst) 1 idleTime maxResources
@@ -271,13 +274,13 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap (Cl
                                 Right v -> return v
                                 Left (err :: SomeException) ->
                                     case fromException err of
-                                        Just (er :: TimeoutException) -> hasLocked $ refreshShardmapAction Nothing >> throwIO er
+                                        Just (er :: TimeoutException) -> hasLocked (refreshShardmapAction Nothing) >> throwIO er
                                         _ -> getRandomConnection nc conn >>= (`executeRequests` r)
                 refreshedShardMapAndNodeConnsIORef <- IOR.newIORef Nothing
-                mapM (\completedRequest@(CompletedRequest index request response) -> 
+                mapM (\completedRequest@(CompletedRequest index request response) ->
                     case response of
                         (Error errString) | (B.isPrefixOf "MOVED" errString || B.isPrefixOf "TRYAGAIN" errString) -> CompletedRequest index request <$> refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef (hasLocked $ refreshShardmapAction (Just nc)) request
-                        (askingRedirection -> Just (host, port)) -> do 
+                        (askingRedirection -> Just (host, port)) -> do
                                 refreshedShardMapAndNodeConns <- fromMaybeM (hasLocked $ refreshShardmapAction (Just nc)) $ IOR.readIORef refreshedShardMapAndNodeConnsIORef
                                 maybeAskNode <- nodeConnWithHostAndPort refreshedShardMapAndNodeConns host port
                                 case maybeAskNode of
@@ -302,8 +305,8 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap (Cl
         replies <- requestNode reqTimeout nodeConn $ map rawRequest nodeRequests
         return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
     refreshShardMapAndRetryRequest :: IOR.IORef (Maybe (ShardMap, NodeConnectionMap)) -> IO (ShardMap, NodeConnectionMap) -> [B.ByteString] -> IO Reply
-    refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request =  do 
-        (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new )) $ 
+    refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request =  do
+        (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new)) $
                                         IOR.readIORef refreshedShardMapAndNodeConnsIORef
         nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request
         head <$> requestNode reqTimeout (head nodeConns) [request]
@@ -325,8 +328,8 @@ evaluateTransactionPipeline refreshShardmapAction conn requests' = do
     -- the commands in a transaction are applied and some are not. Better to
     -- fail early.
     hashSlot <- hashSlotForKeys (CrossSlotException requests) keys
-    (ShardMap shardMap, nodeConns) <- hasLocked $ readMVar shardNodeVar
-    nodeConn <- nodeConnForHashSlot (ShardMap shardMap, nodeConns) ("evaluateTransactionPipeline" : head requests) hashSlot
+    (sm, nodeConns) <- hasLocked $ readMVar shardNodeVar
+    nodeConn <- nodeConnForHashSlot (sm, nodeConns) ("evaluateTransactionPipeline" : head requests) hashSlot
     -- catch the exception thrown, send the command to random node.
     -- This change is required to handle the cluster topology change.
     eresps <- try $ requestNode reqTimeout nodeConn requests
@@ -386,9 +389,9 @@ evaluateTransactionPipeline refreshShardmapAction conn requests' = do
         []          -> return $ Right resps) resps
 
 nodeConnForHashSlot :: (ShardMap, NodeConnectionMap) -> [B.ByteString] -> HashSlot -> IO NodeConnection
-nodeConnForHashSlot (ShardMap shardMap, nodeConnsMap) errInfo hashSlot = do
+nodeConnForHashSlot (sm, nodeConnsMap) errInfo hashSlot = do
     node <-
-        case IntMap.lookup (fromEnum hashSlot) shardMap of
+        case IntMap.lookup (fromEnum hashSlot) (shardMapSlots sm) of
             Nothing -> throwIO $ MissingNodeException ("HashSlot lookup failed in nodeConnForHashSlot" : errInfo)
             Just (Shard master _) -> return master
     case HM.lookup (nodeId node) nodeConnsMap of
@@ -434,7 +437,7 @@ nodeConnWithHostAndPort (shardMap, nodeConns) host port = do
         Just node -> return (HM.lookup (nodeId node) nodeConns)
 
 nodeConnectionForCommand :: ShardMap -> NodeConnectionMap -> CMD.InfoMap -> [B.ByteString] -> IO [NodeConnection]
-nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request =
+nodeConnectionForCommand sm nodeConns infoMap request =
     case request of
         ("FLUSHALL" : _) -> allNodes
         ("FLUSHDB" : _) -> allNodes
@@ -443,29 +446,29 @@ nodeConnectionForCommand (ShardMap shardMap) nodeConns infoMap request =
         _ -> do
             keys <- requestKeys infoMap request
             hashSlot <- hashSlotForKeys (CrossSlotException [request]) keys
-            node <- case IntMap.lookup (fromEnum hashSlot) shardMap of
+            node <- case IntMap.lookup (fromEnum hashSlot) (shardMapSlots sm) of
                 Nothing -> throwIO $ MissingNodeException ("HashSlot lookup failed in nodeConnectionForCommand" : request)
                 Just (Shard master _) -> return master
             maybe (throwIO $ MissingNodeException ("NodeId lookup failed in nodeConnectionForCommand" : request)) (return . return) (HM.lookup (nodeId node) nodeConns)
     where
         allNodes = do
-            maybeNodes <- allMasterNodes (ShardMap shardMap) nodeConns
+            maybeNodes <- allMasterNodes sm nodeConns
             case maybeNodes of
                 Nothing -> throwIO $ MissingNodeException ("Master node lookup failed" : request)
                 Just allNodes' -> return allNodes'
 
 allMasterNodes :: ShardMap -> NodeConnectionMap -> IO (Maybe [NodeConnection])
-allMasterNodes (ShardMap shardMap) nodeConns = do
+allMasterNodes sm nodeConns = do
     return $ mapM (flip HM.lookup nodeConns) onlyMasterNodeIds
   where
-    onlyMasterNodeIds = nubOrd $ (\(Shard master _) -> nodeId master) <$> (IntMap.elems shardMap)
+    onlyMasterNodeIds = nubOrd $ (\(Shard master _) -> nodeId master) <$> (IntMap.elems (shardMapSlots sm))
 
 requestNode :: Int -> NodeConnection -> [[B.ByteString]] -> IO [Reply]
 requestNode requestNodeTimeout (NodeConnection pool _) requests = withResource pool $ \(ctx, lastRecvRef) -> do
     mayberesp <- timeout requestNodeTimeout $ requestNodeImpl ctx lastRecvRef
     case mayberesp of
-      Just a    -> return a
-      Nothing   -> putStrLn "timeout happened" *> throwIO (TimeoutException "Request Timeout")
+      Just a  -> return a
+      Nothing -> throwIO (TimeoutException "Request Timeout")
     where
     requestNodeImpl :: CC.ConnectionContext -> IOR.IORef (Maybe B.ByteString) -> IO [Reply]
     requestNodeImpl ctx lastRecvRef = do
@@ -490,7 +493,7 @@ requestNode requestNodeTimeout (NodeConnection pool _) requests = withResource p
 
 {-# INLINE nodes #-}
 nodes :: ShardMap -> [Node]
-nodes (ShardMap shardMap) = concatMap snd $ IntMap.toList $ fmap shardNodes shardMap where
+nodes sm = concatMap snd $ IntMap.toList $ fmap shardNodes (shardMapSlots sm) where
     shardNodes :: Shard -> [Node]
     shardNodes (Shard master slaves) = master:slaves
 
@@ -515,8 +518,8 @@ requestMasterNodes conn@(Connection _ _ (ClusterConfig reqTimeout)) req = do
 
 masterNodes :: Connection -> IO [NodeConnection]
 masterNodes (Connection shardNodeVar _ _) = do
-    (ShardMap shardMap, nodeConns) <- hasLocked $ readMVar shardNodeVar
-    let masterNodeIds = map (\(Shard m _) -> nodeId m) $ IntMap.elems shardMap
+    (sm, nodeConns) <- hasLocked $ readMVar shardNodeVar
+    let masterNodeIds = map (\(Shard m _) -> nodeId m) $ IntMap.elems (shardMapSlots sm)
     return $ mapMaybe (`HM.lookup` nodeConns) (nubOrd masterNodeIds)
 
 getRandomConnection :: NodeConnection -> Connection -> IO NodeConnection

--- a/src/Database/Redis/Cluster.hs
+++ b/src/Database/Redis/Cluster.hs
@@ -36,7 +36,7 @@ import Data.Map(fromListWith, assocs)
 import Data.Function(on)
 import Control.Exception(Exception, SomeException, throwIO, BlockedIndefinitelyOnMVar(..), catches, Handler(..), try, fromException)
 import Data.Pool(Pool, createPool, withResource, destroyAllResources)
-import Control.Concurrent.MVar(MVar, newMVar, readMVar, modifyMVar)
+import Control.Concurrent.MVar(MVar, newMVar, modifyMVar, withMVar)
 import Control.Monad(zipWithM, replicateM)
 import Database.Redis.Cluster.HashSlot(HashSlot(..), keyToSlot, numHashSlots)
 import qualified Database.Redis.ConnectionContext as CC
@@ -67,7 +67,7 @@ import Control.Applicative((<|>))
 -- | A connection to a redis cluster, it is composed of a map from Node IDs to
 -- | 'NodeConnection's, a 'Pipeline', and a 'ShardMap'
 
-data Connection = Connection (MVar (ShardMap, NodeConnectionMap)) CMD.InfoMap ClusterConfig
+data Connection = Connection (IOR.IORef (ShardMap, NodeConnectionMap)) (MVar ()) CMD.InfoMap ClusterConfig
 
 -- | A connection to a single node in the cluster, similar to 'ProtocolPipelining.Connection'
 data NodeConnection = NodeConnection (Pool (CC.ConnectionContext, IOR.IORef (Maybe B.ByteString))) NodeID
@@ -152,10 +152,11 @@ instance Exception TimeoutException
 createClusterConnectionPools :: (Host -> CC.PortID -> IO CC.ConnectionContext) -> Int -> Time.NominalDiffTime -> [CMD.CommandInfo] -> ShardMap -> Maybe Double -> IO Connection
 createClusterConnectionPools withAuth maxResources idleTime commandInfos shardMap requestTimeoutSeconds = do
         nodeConns <- nodeConnections
-        shardNodeVar <- newMVar (shardMap, nodeConns)
+        shardNodeVar <- IOR.newIORef (shardMap, nodeConns)
+        refreshLock <- newMVar ()
         nodeRequestTimeout <- round . (\x -> (x :: Time.NominalDiffTime) * 1000000) . realToFrac . fromMaybe (5 :: Double) . (requestTimeoutSeconds <|> ). (>>= readMaybe) <$> lookupEnv "REDIS_REQUEST_NODE_TIMEOUT"
         let clusterConfig = ClusterConfig { requestTimeout = nodeRequestTimeout }
-        return $ Connection shardNodeVar (CMD.newInfoMap commandInfos) clusterConfig where
+        return $ Connection shardNodeVar refreshLock (CMD.newInfoMap commandInfos) clusterConfig where
     nodeConnections :: IO (HM.HashMap NodeID NodeConnection)
     nodeConnections = do
       nodeConnectionsList <- mapM (createNodePool withAuth maxResources idleTime) (nubOrd $ nodes shardMap)
@@ -170,9 +171,10 @@ createNodePool withAuth maxResources idleTime (Node nodeid _ host port) = do
     return (nodeid, NodeConnection connectionPool nodeid)
 
 destroyNodeResources :: Connection -> IO ()
-destroyNodeResources (Connection shardNodeVar _ _) =
-    hasLocked $ readMVar shardNodeVar
-    >>= (\(_, nodeConnMap) -> (mapM_ disconnectNode $ HM.elems nodeConnMap))
+destroyNodeResources (Connection shardNodeVar refreshLock _ _) =
+    withMVar refreshLock $ \_ ->
+        IOR.readIORef shardNodeVar
+        >>= (\(_, nodeConnMap) -> (mapM_ disconnectNode $ HM.elems nodeConnMap))
     where
         disconnectNode (NodeConnection nodePool _) = destroyAllResources nodePool
 
@@ -249,8 +251,8 @@ rawResponse (CompletedRequest _ _ r) = r
 -- acceptable in most cases as these errors should only occur in the case of
 -- cluster reconfiguration events, which should be rare.
 evaluatePipeline :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [[B.ByteString]] -> IO [Reply]
-evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap (ClusterConfig reqTimeout)) requests = do
-        (shardMap, nodesConn) <- hasLocked $ readMVar shardNodeVar
+evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar _ infoMap (ClusterConfig reqTimeout)) requests = do
+        (shardMap, nodesConn) <- IOR.readIORef shardNodeVar
         erequestsByNode <- try $ getRequestsByNode shardMap nodesConn
         requestsByNode <- case erequestsByNode of
             Right reqByNode -> pure reqByNode
@@ -306,7 +308,7 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap (Cl
         return $ zipWith (curry (\(PendingRequest i r, rep) -> CompletedRequest i r rep)) nodeRequests replies
     refreshShardMapAndRetryRequest :: IOR.IORef (Maybe (ShardMap, NodeConnectionMap)) -> IO (ShardMap, NodeConnectionMap) -> [B.ByteString] -> IO Reply
     refreshShardMapAndRetryRequest refreshedShardMapAndNodeConnsIORef refreshShardmap request =  do
-        (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.writeIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new)) $
+        (newShardMap, newNodeConn) <- fromMaybeM (hasLocked refreshShardmap >>= (\new -> IOR.atomicWriteIORef refreshedShardMapAndNodeConnsIORef (Just new) >> return new)) $
                                         IOR.readIORef refreshedShardMapAndNodeConnsIORef
         nodeConns <- nodeConnectionForCommand newShardMap newNodeConn infoMap request
         head <$> requestNode reqTimeout (head nodeConns) [request]
@@ -317,7 +319,7 @@ evaluatePipeline refreshShardmapAction conn@(Connection shardNodeVar infoMap (Cl
 evaluateTransactionPipeline :: (Maybe NodeConnection -> IO (ShardMap, NodeConnectionMap)) -> Connection -> [[B.ByteString]] -> IO [Reply]
 evaluateTransactionPipeline refreshShardmapAction conn requests' = do
     let requests = reverse requests'
-    let (Connection shardNodeVar infoMap (ClusterConfig reqTimeout)) = conn
+    let (Connection shardNodeVar _ infoMap (ClusterConfig reqTimeout)) = conn
     keys <- mconcat <$> mapM (requestKeys infoMap) requests
     -- In cluster mode Redis expects commands in transactions to all work on the
     -- same hashslot. We find that hashslot here.
@@ -328,7 +330,7 @@ evaluateTransactionPipeline refreshShardmapAction conn requests' = do
     -- the commands in a transaction are applied and some are not. Better to
     -- fail early.
     hashSlot <- hashSlotForKeys (CrossSlotException requests) keys
-    (sm, nodeConns) <- hasLocked $ readMVar shardNodeVar
+    (sm, nodeConns) <- IOR.readIORef shardNodeVar
     nodeConn <- nodeConnForHashSlot (sm, nodeConns) ("evaluateTransactionPipeline" : head requests) hashSlot
     -- catch the exception thrown, send the command to random node.
     -- This change is required to handle the cluster topology change.
@@ -488,7 +490,7 @@ requestNode requestNodeTimeout (NodeConnection pool _) requests = withResource p
             Scanner.Fail{}       -> CC.errConnClosed
             Scanner.More{}    -> error "Hedis: parseWith returned Partial"
             Scanner.Done rest' r -> do
-                IOR.writeIORef lastRecvRef (Just rest')
+                IOR.atomicWriteIORef lastRecvRef (Just rest')
                 return r
 
 {-# INLINE nodes #-}
@@ -512,19 +514,19 @@ hasLocked action =
 
 
 requestMasterNodes :: Connection -> [B.ByteString] -> IO [Reply]
-requestMasterNodes conn@(Connection _ _ (ClusterConfig reqTimeout)) req = do
+requestMasterNodes conn@(Connection _ _ _ (ClusterConfig reqTimeout)) req = do
     masterNodeConns <- masterNodes conn
     concat <$> mapM (flip (requestNode reqTimeout) [req]) masterNodeConns
 
 masterNodes :: Connection -> IO [NodeConnection]
-masterNodes (Connection shardNodeVar _ _) = do
-    (sm, nodeConns) <- hasLocked $ readMVar shardNodeVar
+masterNodes (Connection shardNodeVar _ _ _) = do
+    (sm, nodeConns) <- IOR.readIORef shardNodeVar
     let masterNodeIds = map (\(Shard m _) -> nodeId m) $ IntMap.elems (shardMapSlots sm)
     return $ mapMaybe (`HM.lookup` nodeConns) (nubOrd masterNodeIds)
 
 getRandomConnection :: NodeConnection -> Connection -> IO NodeConnection
 getRandomConnection nc conn = do
-  let (Connection shardNodeVar _ _) = conn
-  (_, nodeConns) <- hasLocked $ readMVar shardNodeVar
+  let (Connection shardNodeVar _ _ _) = conn
+  (_, nodeConns) <- IOR.readIORef shardNodeVar
   let conns = HM.elems nodeConns
   return $ fromMaybe (head conns) $ find (nc /= ) conns

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -24,11 +24,11 @@ import qualified Network.Socket as NS
 import qualified Data.HashMap.Strict as HM
 import System.Random (randomRIO)
 import System.Environment (lookupEnv)
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Text.Read (readMaybe)
 
 import qualified Database.Redis.ProtocolPipelining as PP
-import Database.Redis.Core(Redis, runRedisInternal, runRedisClusteredInternal)
+import Database.Redis.Core(Redis, runRedisInternal, runRedisClusteredInternal, sendRequest)
 import Database.Redis.Protocol(Reply(..))
 import Database.Redis.Cluster(ShardMap(..), Node(..), Shard(..), NodeConnectionMap)
 import qualified Database.Redis.Cluster as Cluster
@@ -238,10 +238,12 @@ instance Exception ClusterConnectError
 connectCluster :: ConnectInfo -> IO Connection
 connectCluster bootstrapConnInfo@ConnInfo{connectMaxConnections,connectMaxIdleTime,requestTimeout} = do
     conn <- createConnection bootstrapConnInfo
+    epochReply <- runRedisInternal conn (sendRequest ["CLUSTER", "INFO"])
+    let epoch = either (const 0) parseClusterEpoch epochReply
     slotsResponse <- runRedisInternal conn clusterSlots
     shardMap <- case slotsResponse of
         Left e -> throwIO $ ClusterConnectError e
-        Right slots -> shardMapFromClusterSlotsResponse slots
+        Right slots -> shardMapFromClusterSlotsResponse epoch slots
     commandInfos <- runRedisInternal conn command
     case commandInfos of
         Left e -> throwIO $ ClusterConnectError e
@@ -274,8 +276,11 @@ connectWithAuth ConnInfo{connectTLSParams,connectAuth,connectReadOnly,connectTim
 clusterConnectTimeoutinUs :: Time.NominalDiffTime -> Int
 clusterConnectTimeoutinUs = round . (1000000 *) 
 
-shardMapFromClusterSlotsResponse :: ClusterSlotsResponse -> IO ShardMap
-shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr mkShardMap (pure IntMap.empty)  clusterSlotsResponseEntries where
+shardMapFromClusterSlotsResponse :: Int -> ClusterSlotsResponse -> IO ShardMap
+shardMapFromClusterSlotsResponse epoch ClusterSlotsResponse{..} = do
+    slots <- foldr mkShardMap (pure IntMap.empty) clusterSlotsResponseEntries
+    return ShardMap { shardMapSlots = slots, shardMapEpoch = epoch }
+  where
     mkShardMap :: ClusterSlotsResponseEntry -> IO (IntMap.IntMap Shard) -> IO (IntMap.IntMap Shard)
     mkShardMap ClusterSlotsResponseEntry{..} accumulator = do
         accumulated <- accumulator
@@ -291,12 +296,36 @@ shardMapFromClusterSlotsResponse ClusterSlotsResponse{..} = ShardMap <$> foldr m
         in
             Cluster.Node clusterSlotsNodeID role hostname (toEnum clusterSlotsNodePort)
 
+-- Parse cluster_current_epoch from the CLUSTER INFO bulk-string response.
+-- CLUSTER INFO returns lines like "cluster_current_epoch:6\r\n".
+parseClusterEpoch :: Reply -> Int
+parseClusterEpoch (Bulk (Just bs)) =
+    let ls = Char8.lines bs
+        prefix = "cluster_current_epoch:"
+        found = listToMaybe $ mapMaybe (fmap Char8.unpack . Char8.stripPrefix prefix) ls
+    in case found >>= readMaybe of
+        Just n  -> n
+        Nothing -> 0
+parseClusterEpoch _ = 0
+
 refreshShardMap :: ConnectInfo -> Cluster.Connection -> Maybe Cluster.NodeConnection -> IO (ShardMap, NodeConnectionMap)
 refreshShardMap connectInfo@ConnInfo{connectMaxConnections,connectMaxIdleTime} (Cluster.Connection shardNodeVar _ _) nodeConn = do
-    modifyMVar shardNodeVar $ \(_, oldNodeConnMap) -> do
+    modifyMVar shardNodeVar $ \(currentShardMap, oldNodeConnMap) -> do
         newShardMap <- refreshShardMapWithNodeConn nodeConn (HM.elems oldNodeConnMap)
-        newNodeConnMap <- updateNodeConnections newShardMap oldNodeConnMap        
-        return ((newShardMap, newNodeConnMap), (newShardMap, newNodeConnMap))
+        -- Epoch guard: Redis cluster gossip is eventually consistent.
+        -- A CLUSTER SLOTS response from a gossip-lagged node carries a lower
+        -- cluster_current_epoch. Writing it back would overwrite a correct
+        -- post-failover ShardMap with a stale one.
+        -- We skip the guard when either epoch is 0 (parse failed / old node)
+        -- so that a missing CLUSTER INFO never permanently blocks refreshes.
+        let isStale = shardMapEpoch currentShardMap > 0
+                   && shardMapEpoch newShardMap    > 0
+                   && shardMapEpoch newShardMap    < shardMapEpoch currentShardMap
+        if isStale
+            then return ((currentShardMap, oldNodeConnMap), (currentShardMap, oldNodeConnMap))
+            else do
+                newNodeConnMap <- updateNodeConnections newShardMap oldNodeConnMap
+                return ((newShardMap, newNodeConnMap), (newShardMap, newNodeConnMap))
     where
         withAuth :: Cluster.Host -> CC.PortID -> IO CC.ConnectionContext
         withAuth = connectWithAuth connectInfo
@@ -345,12 +374,17 @@ refreshShardMapWithNodeConn maybeNodeConn nodeConnsList = do
 refreshShardMapWithConn :: PP.Connection -> Bool -> IO ShardMap
 refreshShardMapWithConn pipelineConn _ = do
     _ <- PP.beginReceiving pipelineConn
+    -- Fetch cluster_current_epoch from CLUSTER INFO so we can guard against
+    -- stale overwrites: a ShardMap fetched from a gossip-lagged node will have
+    -- a lower epoch and will never be allowed to overwrite a newer one.
+    epochReply  <- runRedisInternal pipelineConn (sendRequest ["CLUSTER", "INFO"])
+    let epoch = either (const 0) parseClusterEpoch epochReply
     slotsResponse <- runRedisInternal pipelineConn clusterSlots
     case slotsResponse of
         Left e -> throwIO $ ClusterConnectError e
-        Right slots -> case clusterSlotsResponseEntries slots of 
+        Right slots -> case clusterSlotsResponseEntries slots of
             [] -> throwIO $ ClusterConnectError $ SingleLine "empty slotsResponse"
-            _ -> shardMapFromClusterSlotsResponse slots
+            _ -> shardMapFromClusterSlotsResponse epoch slots
 
 -- This function gets the byteString from the connectAuth
 getConnectionAuthByteString :: Maybe ConnectAuth -> IO (Maybe B.ByteString)

--- a/src/Database/Redis/Connection.hs
+++ b/src/Database/Redis/Connection.hs
@@ -10,7 +10,7 @@ import qualified Control.Monad.Catch as Catch
 import Control.Monad.IO.Class(liftIO, MonadIO)
 import Control.Monad(when,foldM)
 
-import Control.Concurrent.MVar(modifyMVar)
+import Control.Concurrent.MVar(withMVar)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Char8 as Char8
 import Data.Functor(void)
@@ -34,7 +34,7 @@ import Database.Redis.Cluster(ShardMap(..), Node(..), Shard(..), NodeConnectionM
 import qualified Database.Redis.Cluster as Cluster
 import qualified Database.Redis.ConnectionContext as CC
 import qualified System.Timeout as T
-import Data.IORef(IORef, readIORef)
+import Data.IORef(IORef, readIORef, atomicWriteIORef)
 import Database.Redis.Commands
     ( ping
     , select
@@ -309,23 +309,19 @@ parseClusterEpoch (Bulk (Just bs)) =
 parseClusterEpoch _ = 0
 
 refreshShardMap :: ConnectInfo -> Cluster.Connection -> Maybe Cluster.NodeConnection -> IO (ShardMap, NodeConnectionMap)
-refreshShardMap connectInfo@ConnInfo{connectMaxConnections,connectMaxIdleTime} (Cluster.Connection shardNodeVar _ _) nodeConn = do
-    modifyMVar shardNodeVar $ \(currentShardMap, oldNodeConnMap) -> do
+refreshShardMap connectInfo@ConnInfo{connectMaxConnections,connectMaxIdleTime} (Cluster.Connection shardNodeVar refreshLock _ _) nodeConn =
+    withMVar refreshLock $ \_ -> do
+        (currentShardMap, oldNodeConnMap) <- readIORef shardNodeVar
         newShardMap <- refreshShardMapWithNodeConn nodeConn (HM.elems oldNodeConnMap)
-        -- Epoch guard: Redis cluster gossip is eventually consistent.
-        -- A CLUSTER SLOTS response from a gossip-lagged node carries a lower
-        -- cluster_current_epoch. Writing it back would overwrite a correct
-        -- post-failover ShardMap with a stale one.
-        -- We skip the guard when either epoch is 0 (parse failed / old node)
-        -- so that a missing CLUSTER INFO never permanently blocks refreshes.
-        let isStale = shardMapEpoch currentShardMap > 0
-                   && shardMapEpoch newShardMap    > 0
-                   && shardMapEpoch newShardMap    < shardMapEpoch currentShardMap
-        if isStale
-            then return ((currentShardMap, oldNodeConnMap), (currentShardMap, oldNodeConnMap))
+        let keepCurrent = shardMapEpoch currentShardMap > 0
+                       && shardMapEpoch newShardMap     > 0
+                       && shardMapEpoch newShardMap    <= shardMapEpoch currentShardMap
+        if keepCurrent
+            then return (currentShardMap, oldNodeConnMap)
             else do
                 newNodeConnMap <- updateNodeConnections newShardMap oldNodeConnMap
-                return ((newShardMap, newNodeConnMap), (newShardMap, newNodeConnMap))
+                atomicWriteIORef shardNodeVar (newShardMap, newNodeConnMap)
+                return (newShardMap, newNodeConnMap)
     where
         withAuth :: Cluster.Host -> CC.PortID -> IO CC.ConnectionContext
         withAuth = connectWithAuth connectInfo


### PR DESCRIPTION
Redis cluster gossip is eventually consistent. After a failover, a CLUSTER SLOTS response from a gossip-lagged node carries a lower cluster_current_epoch than the ShardMap already in the MVar. Writing it back would silently overwrite a correct post-failover master mapping with a stale one, causing requests to route to the dead node again.

Changes:
- Promote ShardMap from newtype to a record carrying shardMapEpoch (!Int, the cluster_current_epoch at fetch time)
- Fetch CLUSTER INFO (1 extra round-trip per refresh) to capture the epoch alongside CLUSTER SLOTS in refreshShardMapWithConn and connectCluster
- Add parseClusterEpoch to extract cluster_current_epoch from the CLUSTER INFO bulk-string response
- Add epoch guard in refreshShardMap: if the incoming ShardMap has a strictly lower epoch than the current one (and both epochs are > 0), discard the incoming ShardMap and keep the current one
- Guard skips when either epoch is 0 (CLUSTER INFO parse failure or older Redis version) so a missing epoch never permanently blocks refreshes
- Update all ShardMap pattern matches to use the new record fields